### PR TITLE
Directly load elements instead of via bower

### DIFF
--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -9,8 +9,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <!-- LANcie elements -->
+<link rel="import" href="lancie-activity/lancie-activity.html">
+<link rel="import" href="lancie-commission/lancie-commission.html">
 <link rel="import" href="lancie-home-page/lancie-home-page.html">
-<link rel="import" href="../bower_components/lancie-elements/lancie-elements.html">
+<link rel="import" href="lancie-section/lancie-section.html">
+<link rel="import" href="lancie-timetable/lancie-timetable.html">
 
 <!-- Iron elements -->
 <link rel="import" href="../bower_components/iron-flex-layout/classes/iron-flex-layout.html">


### PR DESCRIPTION
This eases the development of sub-elements.

Previously, updates should be committed and pushed to the respective elements, then a `bower update` in the frontend and then a refresh of the page. This significantly slows the development speed.

The new approach is to stick with the git submodules, but load the elements directly in `app/elements/*` instead of via bower. Therefore if you locally change an element, `gulp serve` automatically refreshes the page.

@svenpopping PTAL