### PR TITLE
Fix double removal of ticket

### DIFF
--- a/app/elements/lancie-ticket-page/lancie-ticket-list-item.html
+++ b/app/elements/lancie-ticket-page/lancie-ticket-list-item.html
@@ -80,7 +80,6 @@ This code may only be used under the BSD style license found at https://github.c
 
     _onAnimationFinish: function() {
       if (!this.opened) {
-        this.style.display = '';
         this.fire('delete-ticket', {ticket: this.ticket});
       }
     },


### PR DESCRIPTION
Fixes #53 
The Style of the ticket was removed, causing the code to ignore the ticket and removing the next one in the list.