### PR TITLE
Add order landing pages

### DIFF
--- a/app/elements/lancie-content.html
+++ b/app/elements/lancie-content.html
@@ -2,6 +2,8 @@
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="lancie-login/lancie-ajax.html">
 <link rel="import" href="lancie-login/lancie-login-check.html">
+<link rel="import" href="lancie-order-success.html">
+<link rel="import" href="lancie-order-failure.html">
 
 <dom-module id="lancie-content">
   <template>
@@ -34,6 +36,14 @@
         <lancie-login-check user="{{user}}">
           <lancie-ticket-page></lancie-ticket-page>
         </lancie-login-check>
+      </div>
+
+      <div data-route="order-success">
+        <lancie-order-success></lancie-order-success>
+      </div>
+
+      <div data-route="order-failure">
+        <lancie-order-failure></lancie-order-failure>
       </div>
     </iron-pages>
   </template>

--- a/app/elements/lancie-order-failure.html
+++ b/app/elements/lancie-order-failure.html
@@ -1,0 +1,24 @@
+<link rel="import" href="lancie-section/lancie-section.html">
+
+<dom-module id="lancie-order-failure">
+  <template>
+    <lancie-section>
+      <div>
+        <h1>Order Failed</h1>
+
+        <p>
+          Hmm, there seemed to have gone something wrong.
+          If you have paid for the tickets please <a href="mailto:lancie@ch.tudelft.nl">send us an email</a> containing your email-adres and username.
+          We will then check what went wrong.
+        </p>
+
+        <a href="/">Return to the homepage</a>
+      </div>
+    </lancie-section>
+  </template>
+  <script>
+    Polymer({
+      is: 'lancie-order-failure'
+    });
+  </script>
+</dom-module>

--- a/app/elements/lancie-order-success.html
+++ b/app/elements/lancie-order-success.html
@@ -1,0 +1,23 @@
+<link rel="import" href="lancie-section/lancie-section.html">
+
+<dom-module id="lancie-order-success">
+  <template>
+    <lancie-section>
+      <div>
+        <h1>Order Successful!</h1>
+
+        <p>
+          Congratulations, your ticket(s) were successfully ordered and are now available in your area.
+          Click my area below or in header to go to your area to manage your tickets and profile.
+        </p>
+
+        <a href="/my-area">My Area</a>
+      </div>
+    </lancie-section>
+  </template>
+  <script>
+    Polymer({
+      is: 'lancie-order-success'
+    });
+  </script>
+</dom-module>

--- a/app/elements/routing.html
+++ b/app/elements/routing.html
@@ -27,6 +27,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     app.route = 'my-area';
   });
 
+  page('/ordersuccess', function() {
+    app.route = 'order-success'
+  });
+
+  page('/orderfailure', function() {
+    app.route = 'order-failure'
+  });
+
   // add #! before urls
   page({
     hashbang: true


### PR DESCRIPTION
Fixes #52 

For architecture reasons, the pages are on separate links: `areafiftylan.nl/#!/ordersuccess` and `areafiftylan.nl/#!/orderfailure`