### PR TITLE
Fix tooltip for lancie-sections

### DIFF
--- a/app/elements/lancie-home-page/lancie-home-page.html
+++ b/app/elements/lancie-home-page/lancie-home-page.html
@@ -48,11 +48,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <lancie-image-slider></lancie-image-slider>
     </lancie-section>
 
-    <lancie-section type="primary" title="Partners &amp; Sponsors">
+    <lancie-section type="primary" header="Partners &amp; Sponsors">
       <lancie-sponsors></lancie-sponsors>
     </lancie-section>
 
-    <lancie-section type="secondary" title="Area FiftyLAN">
+    <lancie-section type="secondary" header="Area FiftyLAN">
       <div>
         <p>
           Area FiftyLAN is the hottest gaming event of the TU Delft.
@@ -76,7 +76,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </lancie-section>
 
-    <lancie-section type="primary" title="What do you get?">
+    <lancie-section type="primary" header="What do you get?">
       <div>
         <p>
           Early bird tickets will soon be available and will cost €37.50*, regular tickets will cost €40*.
@@ -95,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </lancie-section>
 
-    <lancie-section type="secondary" title="Official Tournaments">
+    <lancie-section type="secondary" header="Official Tournaments">
       <div>
         <p>All official tournaments are listed below. These tournaments will be hosted by AreaFiftyLAN and there are
           some awesome prizes to win! Is your favorite game not listed? No worries! If you have a great idea for a
@@ -106,7 +106,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </lancie-section>
 
-    <lancie-section type="secondary" title="Organize your own tournament!">
+    <lancie-section type="secondary" header="Organize your own tournament!">
       <iron-ajax
          auto
          url="{{markdownUrl}}"
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </marked-element>
     </lancie-section>
 
-    <lancie-section title="2nd LANcie of W.I.S.V. 'Christiaan Huygens'">
+    <lancie-section header="2nd LANcie of W.I.S.V. 'Christiaan Huygens'">
       <lancie-commission json="/scripts/commission.json"></lancie-commission>
     </lancie-section>
     <lancie-section type="primary full no-padding">

--- a/app/elements/lancie-section/lancie-section.html
+++ b/app/elements/lancie-section/lancie-section.html
@@ -70,8 +70,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-media-query query="max-width: 530px" query-matches="{{small}}"></iron-media-query>
     <div class$="{{_setType(type)}}">
       <div class="content">
-        <template is="dom-if" if="{{title}}">
-          <h1>{{title}}</h1>
+        <template is="dom-if" if="{{header}}">
+          <h1>{{header}}</h1>
         </template>
         <div class$="{{_setOrientation(small)}}">
           <content></content>
@@ -88,20 +88,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       properties: {
         type: {
           type: String,
-          value: "primary",
+          value: 'primary',
           notify: true
         },
-        title: {
+        header: {
           type: String,
-          value: "",
+          value: '',
           notify: true
         }
       },
       _setType: function() {
-        return "container " + this.type;
+        return 'container ' + this.type;
       },
       _setOrientation: function(horizontal) {
-        return "layout " + (horizontal ? "vertical" : "horizontal");
+        return 'layout ' + (horizontal ? 'vertical' : 'horizontal');
       }
     });
   })();


### PR DESCRIPTION
Since `title` is a native attribute, the whole `lancie-section` will have a tooltip. Therefore we must change the attribute name to a non-native attribute to suppress the tooltip.

Fixes #79 