### PR TITLE
Add google-maps api key

### DIFF
--- a/app/elements/lancie-home-page/lancie-home-page.html
+++ b/app/elements/lancie-home-page/lancie-home-page.html
@@ -125,10 +125,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <lancie-commission json="/scripts/commission.json"></lancie-commission>
     </lancie-section>
     <lancie-section type="primary full no-padding">
-      <google-map latitude="51.999020" longitude="4.371175" zoom="14" disable-zoom fit-to-markers draggable="false">
-        <google-map-marker latitude="51.999020" longitude="4.371175"
-            draggable="true" title="Area FiftyLAN"></google-map-marker>
-      </google-map>
+      <iron-ajax
+        auto
+        url="/api/v1/googlemapskey"
+        handle-as="json"
+        last-response="{{googleMapsToken}}"></iron-ajax>
+      <template is="dom-if" if="{{googleMapsToken}}" restamp="true">
+        <google-map latitude="51.999020" longitude="4.371175" zoom="14" disable-zoom fit-to-markers draggable="false" api-key="{{googleMapsToken.message}}">
+          <google-map-marker latitude="51.999020" longitude="4.371175"
+              draggable="true" title="Area FiftyLAN"></google-map-marker>
+        </google-map>
+      </template>
     </lancie-section>
   </template>
 </dom-module>

--- a/app/elements/lancie-home-page/lancie-home-page.html
+++ b/app/elements/lancie-home-page/lancie-home-page.html
@@ -127,7 +127,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <lancie-section type="primary full no-padding">
       <iron-ajax
         auto
-        url="/api/v1/googlemapskey"
+        url="/api/v1/web/properties/googlemapskey"
         handle-as="json"
         last-response="{{googleMapsToken}}"></iron-ajax>
       <template is="dom-if" if="{{googleMapsToken}}" restamp="true">


### PR DESCRIPTION
See instructions on the server on how to generate your own key.

Requires https://github.com/AreaFiftyLAN/lancie-api/pull/156
Fixes #119 