### PR TITLE
Hotfix incorrect colors for forms

### DIFF
--- a/app/elements/lancie-login/lancie-login-form.html
+++ b/app/elements/lancie-login/lancie-login-form.html
@@ -31,6 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-right: auto;
         margin-top: 10px;
         display: block;
+        --paper-card-header-color: #ffffff;
         max-width: 500px;
 
         --paper-card-header-text: {
@@ -38,8 +39,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           text-align: center;
           padding-left: 0;
         }
-
-        --paper-card-header-color: #ffffff;
       }
 
       .btn {

--- a/app/elements/lancie-message-card.html
+++ b/app/elements/lancie-message-card.html
@@ -15,6 +15,7 @@
         margin-right: auto;
         margin-top: 10px;
         display: block;
+        --paper-card-header-color: #ffffff;
         max-width: 500px;
 
         --paper-card-header-text: {
@@ -23,7 +24,6 @@
           padding-left: 0;
         }
 
-        --paper-card-header-color: #ffffff;
       }
     </style>
 

--- a/app/elements/lancie-ticket-page/lancie-ticket-page.css
+++ b/app/elements/lancie-ticket-page/lancie-ticket-page.css
@@ -41,8 +41,8 @@ paper-card {
   width: 100%;
   /*max-width: 420px;*/
   /*width: 420px;*/
-  margin: 8px;
   --paper-card-header-color: #ffe574;
+  margin: 8px;
   --paper-card-header: {
     background-color: #1a2b43;
   }

--- a/app/elements/lancie-ticket-page/lancie-ticket-profile-intercept.html
+++ b/app/elements/lancie-ticket-page/lancie-ticket-profile-intercept.html
@@ -40,6 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-right: auto;
         margin-top: 10px;
         display: block;
+        --paper-card-header-color: #ffffff;
         max-width: 800px;
 
         --paper-card-header-text: {
@@ -47,8 +48,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           text-align: center;
           padding-left: 0;
         }
-
-        --paper-card-header-color: #ffffff;
       }
 
       paper-tooltip {


### PR DESCRIPTION
This is actually an upstream bug which should be fixed in Polymer.
Reproducible with gulp `serve:dist` with minified CSS and a
mix-in without brackets