### PR TITLE
Enable shadow dom and fix minor styling issues

### DIFF
--- a/app/elements/lancie-activity/lancie-activity-dialog.html
+++ b/app/elements/lancie-activity/lancie-activity-dialog.html
@@ -23,6 +23,9 @@ This code may only be used under the BSD style license found at https://github.c
 <dom-module id="lancie-activity-dialog">
   <style include="iron-flex iron-flex-alignment"></style>
   <style>
+    :host {
+      display: block;
+    }
     paper-dialog.small-dialog {
       position: fixed;
       top: 0;
@@ -31,13 +34,14 @@ This code may only be used under the BSD style license found at https://github.c
       bottom: 0;
       margin: 0;
     }
-    paper-dialog.small-dialog paper-dialog-scrollable ::shadow #scrollable {
-      height: calc(100vh);
-    }
     .action-dialog-header {
       position: relative;
-      margin: 0;
-      padding: 0;
+      /*
+        !important is here required because there is no mix-in
+        in paper-dialog-behavior to override the ::content css.
+      */
+      margin: 0 !important;
+      padding: 0 !important;
       height: 120px;
       background-position: 50% 25%;
       background-size: 100% auto;
@@ -62,7 +66,7 @@ This code may only be used under the BSD style license found at https://github.c
       max-width: 850px;
       height: 350px;
     }
-    paper-dialog-scrollable ::shadow #scrollable {
+    paper-dialog-scrollable {
       height: 100%;
     }
     lancie-activity-sponsor {
@@ -94,7 +98,7 @@ This code may only be used under the BSD style license found at https://github.c
           <paper-icon-button icon="close" on-tap="closeDialog"></paper-icon-button>
         </div>
       </div>
-      <paper-dialog-scrollable>
+      <paper-dialog-scrollable class$="{{_dialogClass(queryMatches, data.sponsor)}}">
         <div class$="{{_contentClass(queryMatches)}}">
           <lancie-activity-content data="{{data}}"></lancie-activity-content>
           <lancie-activity-sponsor sponsor="{{data.sponsor}}" prizes="{{data.prizes}}"></lancie-activity-sponsor>
@@ -147,7 +151,7 @@ This code may only be used under the BSD style license found at https://github.c
      * @return {String}             String of the class for the content of the paper-dialog
      */
     _contentClass: function(mediaQuery) {
-      return 'action-dialog-header layout start flex ' + (mediaQuery ? 'vertical' : 'horizontal');
+      return 'layout start flex ' + (mediaQuery ? 'vertical' : 'horizontal');
     }
   });
   </script>

--- a/app/elements/lancie-my-area/lancie-my-area.html
+++ b/app/elements/lancie-my-area/lancie-my-area.html
@@ -10,9 +10,9 @@
   <template>
     <style include="iron-flex iron-flex-alignment iron-flex-factors"></style>
     <style>
-    :host {
-      display: block;
-    }
+      :host {
+        display: block;
+      }
 
     .content {
       width: 100%;

--- a/app/elements/lancie-sponsors/lancie-sponsor-item.html
+++ b/app/elements/lancie-sponsors/lancie-sponsor-item.html
@@ -18,13 +18,6 @@ This code may only be used under the BSD style license found at https://github.c
         position: relative;
       }
 
-      :host(:after) {
-        padding-top: 51.625%;
-        /* 16:9 ratio */
-        display: block;
-        content: '';
-      }
-
       iron-image {
         display: block;
         height: 100%;

--- a/app/elements/lancie-sponsors/lancie-sponsors.html
+++ b/app/elements/lancie-sponsors/lancie-sponsors.html
@@ -29,6 +29,13 @@
         max-width: 250px;
       }
 
+      lancie-sponsor-item:after {
+        padding-top: 51.625%;
+        /* 16:9 ratio */
+        display: block;
+        content: '';
+      }
+
       .premium-sponsors lancie-sponsor-item.topicus {
         margin-top: -33px;
         max-width: 264px;

--- a/app/index.html
+++ b/app/index.html
@@ -55,13 +55,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
   'use strict';
     window.Polymer = window.Polymer || {};
-    // window.Polymer.dom = 'shadow';
-  </script>
-
-  <script>
-    window.Polymer = {
-      lazyRegister: true
-    };
+    window.Polymer.lazyRegister = true;
+    window.Polymer.dom = 'shadow';
   </script>
 
   <!-- will be replaced with elements/elements.vulcanized.html -->

--- a/app/index.html
+++ b/app/index.html
@@ -52,6 +52,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- endbuild-->
 
   <script type="text/javascript" src="bower_components/moment/min/moment.min.js" async></script>
+  <script>
+  'use strict';
+    window.Polymer = window.Polymer || {};
+    // window.Polymer.dom = 'shadow';
+  </script>
 
   <script>
     window.Polymer = {
@@ -64,9 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- endreplace-->
 
   <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  /* globals ga */
+  /*jshint -W030 */
+  (function(i,s,o,g,r,a,m){i.GoogleAnalyticsObject=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-60209049-1', 'auto');
   ga('send', 'pageview');


### PR DESCRIPTION
There were some styling issues with the activity dialogs, they should be properly using mix-ins now. Also `:host(:after)` appears to be illegal in shadow dom, therefore these rules are moved to `lancie-sponsors`.

Fixes #128 