### PR TITLE
Clean up gulpfile and apply versioning to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "gulp-minify-html": "^1.0.2",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-rev": "^7.0.0",
+    "gulp-rev-replace": "^0.4.3",
     "gulp-size": "^2.0.0",
     "gulp-style-modules": "^0.1.0",
     "gulp-uglify": "^1.2.0",


### PR DESCRIPTION
`index.html` can not be versioned sadly, but we can version `index.js`. This allows infinite caching of `.js` since it will automatically redownload if the hash of the `.js` is changed. Also I cleaned up a lot of old tasks that are already handled by `polybuild` in the `build` step.

Run `npm install` to download the new dependencies.

Fixes #154 