### PR TITLE
Bump Polymer to 1.4.0 and fix some styling issues

### DIFF
--- a/app/elements/lancie-activity/lancie-activities.html
+++ b/app/elements/lancie-activity/lancie-activities.html
@@ -13,7 +13,7 @@ This code may only be used under the BSD style license found at https://github.c
 
 <dom-module id="lancie-activities">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-activity/lancie-activity-button.html
+++ b/app/elements/lancie-activity/lancie-activity-button.html
@@ -12,7 +12,7 @@ This code may only be used under the BSD style license found at https://github.c
 
 <dom-module id="lancie-activity-button">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-activity/lancie-activity-dialog.html
+++ b/app/elements/lancie-activity/lancie-activity-dialog.html
@@ -21,7 +21,7 @@ This code may only be used under the BSD style license found at https://github.c
 <link rel="import" href="lancie-activity-sponsor.html">
 
 <dom-module id="lancie-activity-dialog">
-  <style include="iron-flex iron-flex-alignment">
+  <style include="iron-flex iron-flex-alignment"></style>
   <style>
     paper-dialog.small-dialog {
       position: fixed;

--- a/app/elements/lancie-activity/lancie-activity-footer.html
+++ b/app/elements/lancie-activity/lancie-activity-footer.html
@@ -8,7 +8,7 @@ This code may only be used under the BSD style license found at https://github.c
 
 <dom-module id="lancie-activity-footer">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-commission/lancie-commission-member.html
+++ b/app/elements/lancie-commission/lancie-commission-member.html
@@ -2,7 +2,7 @@
 
 <dom-module id="lancie-commission-member">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         margin: 5px;

--- a/app/elements/lancie-commission/lancie-commission.html
+++ b/app/elements/lancie-commission/lancie-commission.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="lancie-commission-member.html">
 <dom-module id="lancie-commission">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-home-page/lancie-home-page.html
+++ b/app/elements/lancie-home-page/lancie-home-page.html
@@ -42,6 +42,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       height: 400px;
       width: 100%;
     }
+
+    .google-maps-section {
+      height: 400px;
+      width: 100%;
+      display: block;
+    }
   </style>
   <template>
     <lancie-section type="secondary full no-padding">
@@ -124,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <lancie-section header="2nd LANcie of W.I.S.V. 'Christiaan Huygens'">
       <lancie-commission json="/scripts/commission.json"></lancie-commission>
     </lancie-section>
-    <lancie-section type="primary full no-padding">
+    <lancie-section type="google-maps-section primary full no-padding">
       <iron-ajax
         auto
         url="/api/v1/web/properties/googlemapskey"

--- a/app/elements/lancie-home-page/lancie-image-slider.html
+++ b/app/elements/lancie-home-page/lancie-image-slider.html
@@ -3,7 +3,7 @@
 
 <dom-module id="lancie-image-slider">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-login/lancie-login-form.html
+++ b/app/elements/lancie-login/lancie-login-form.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-login-form">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-my-area/lancie-my-area.html
+++ b/app/elements/lancie-my-area/lancie-my-area.html
@@ -8,7 +8,7 @@
 
 <dom-module id="lancie-my-area">
   <template>
-    <style include="iron-flex iron-flex-alignment iron-flex-factors">
+    <style include="iron-flex iron-flex-alignment iron-flex-factors"></style>
     <style>
     :host {
       display: block;

--- a/app/elements/lancie-password/lancie-password-reset-success.html
+++ b/app/elements/lancie-password/lancie-password-reset-success.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-password-reset-success">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-password/lancie-password-reset.html
+++ b/app/elements/lancie-password/lancie-password-reset.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-password-reset">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-password/lancie-request-password-reset-success.html
+++ b/app/elements/lancie-password/lancie-request-password-reset-success.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-request-password-reset-success">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-password/lancie-request-password-reset.html
+++ b/app/elements/lancie-password/lancie-request-password-reset.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-request-password-reset">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-section/lancie-section.html
+++ b/app/elements/lancie-section/lancie-section.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../bower_components/marked-element/marked-element.html" />
 <dom-module id="lancie-section">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
     :host {
       display: block;

--- a/app/elements/lancie-sponsors/lancie-sponsors.html
+++ b/app/elements/lancie-sponsors/lancie-sponsors.html
@@ -8,7 +8,7 @@
 
 <dom-module id="lancie-sponsors">
   <template>
-    <style include="iron-flex iron-flex-alignment iron-flex-factors">
+    <style include="iron-flex iron-flex-alignment iron-flex-factors"></style>
     <style>
       :host {
         display: block;

--- a/app/elements/lancie-ticket-page/lancie-ticket-profile-intercept.html
+++ b/app/elements/lancie-ticket-page/lancie-ticket-profile-intercept.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="lancie-ticket-profile-intercept">
   <template>
-    <style include="iron-flex iron-flex-alignment">
+    <style include="iron-flex iron-flex-alignment"></style>
     <style>
       :host {
         display: block;

--- a/app/index.html
+++ b/app/index.html
@@ -53,6 +53,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script type="text/javascript" src="bower_components/moment/min/moment.min.js" async></script>
 
+  <script>
+    window.Polymer = {
+      lazyRegister: true
+    };
+  </script>
+
   <!-- will be replaced with elements/elements.vulcanized.html -->
   <link rel="import" href="elements/elements.html" async>
   <!-- endreplace-->

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "google-map": "GoogleWebComponents/google-map#~1.1.7",
     "google-youtube": "GoogleWebComponents/google-youtube#~1.1.2",
     "moment": "momentjs#~2.10.6",
-    "polymer": "polymer/polymer#^1.3.0"
+    "polymer": "polymer/polymer#^1.4.0"
   },
   "devDependencies": {
     "web-component-tester": "*",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "google-map": "GoogleWebComponents/google-map#~1.1.7",
     "google-youtube": "GoogleWebComponents/google-youtube#~1.1.2",
     "moment": "momentjs#~2.10.6",
-    "polymer": "polymer/polymer#1.2.4"
+    "polymer": "polymer/polymer#^1.3.0"
   },
   "devDependencies": {
     "web-component-tester": "*",


### PR DESCRIPTION
The styling issue in 1.3.0 has been fixed in 1.3.1, so we can once again use the latest version of Polymer.