### PR TITLE
Promote giveaway on frontpage

### DIFF
--- a/app/elements/lancie-home-page/lancie-image-slider.html
+++ b/app/elements/lancie-home-page/lancie-image-slider.html
@@ -131,7 +131,6 @@
           </div>
           <span class="tickets">Order your tickets <a href="/tickets">here!</a></span>
           <br />
-          icons:warning
           <paper-card heading="Order your ticket before May 15th and win one of two €20 Steam Giftcards!"></paper-card>
         </div>
         <div class="image-slider">

--- a/app/elements/lancie-home-page/lancie-image-slider.html
+++ b/app/elements/lancie-home-page/lancie-image-slider.html
@@ -113,11 +113,9 @@
         }
 
         paper-card {
-          max-width: 500px;
           --paper-card-background-color:#ffe574;
           --paper-card-header-text {
             color: #1a2b43;
-
         }
       }
     </style>
@@ -133,7 +131,8 @@
           </div>
           <span class="tickets">Order your tickets <a href="/tickets">here!</a></span>
           <br />
-          <paper-card heading="Order your ticket before May 15th and win one of two €20 Steam Giftcards!" class="lime"></paper-card>
+          icons:warning
+          <paper-card heading="Order your ticket before May 15th and win one of two €20 Steam Giftcards!"></paper-card>
         </div>
         <div class="image-slider">
           <template is="dom-repeat" items="{{images}}" index-as="index">

--- a/app/elements/lancie-home-page/lancie-image-slider.html
+++ b/app/elements/lancie-home-page/lancie-image-slider.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../bower_components/iron-image/iron-image.html">
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
 
 <dom-module id="lancie-image-slider">
   <template>
@@ -110,6 +111,14 @@
         .content .tickets {
           font-size: 28px;
         }
+
+        paper-card {
+          max-width: 500px;
+          --paper-card-background-color:#ffe574;
+          --paper-card-header-text {
+            color: #1a2b43;
+
+        }
       }
     </style>
     <div>
@@ -123,6 +132,8 @@
               sizing="contain"></iron-image>
           </div>
           <span class="tickets">Order your tickets <a href="/tickets">here!</a></span>
+          <br />
+          <paper-card heading="Order your ticket before May 15th and win one of two €20 Steam Giftcards!" class="lime"></paper-card>
         </div>
         <div class="image-slider">
           <template is="dom-repeat" items="{{images}}" index-as="index">


### PR DESCRIPTION
Adds a paper-card to the front end to point attention to the giveaway

![image](https://cloud.githubusercontent.com/assets/3198784/15214436/58652a20-184d-11e6-959b-5eb9c6eeea44.png)
