### PR TITLE
Added prizes for Hearthstone

### DIFF
--- a/app/scripts/activity.json
+++ b/app/scripts/activity.json
@@ -128,7 +128,9 @@
       "website": "http://eu.battle.net/hearthstone/en/"
     },
     "prizes": [
-      "T.B.A."
+      "Samsung 850 EVO 500GB",
+      "Samsung 850 EVO 250GB",
+      "Samsung 850 EVO 120GB"
     ],
     "format": "1 vs 1",
     "startingDateTime": {


### PR DESCRIPTION
The following prizes have been added
      "Samsung 850 EVO 500GB",
      "Samsung 850 EVO 250GB",
      "Samsung 850 EVO 120GB"