### PR TITLE
Fix missing validation method for login username

### DIFF
--- a/src/lancie-login/lancie-login-form.html
+++ b/src/lancie-login/lancie-login-form.html
@@ -91,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div hidden$="{{!registering}}">
           <paper-material class="errormessage" hidden$="{{!registerError}}">{{registerErrorMessage}}</paper-material>
           <paper-material class="errormessage" hidden$="{{!passwordError}}">{{passwordErrorMessage}}</paper-material>
-          <gold-email-input id="registerUsername" label="Username" name="Username" value="{{username}}" error-message="Username should be a valid email address." on-blur="validateUsername" required></gold-email-input>
+          <gold-email-input id="registerUsername" label="Username" name="Username" value="{{username}}" error-message="Username should be a valid email address." on-blur="validateRegisterUsername" required></gold-email-input>
           <paper-input label="Password" name="password" type="password" value="{{password}}"></paper-input>
           <paper-input label="Retype password" type="password" value="{{secondPassword}}"></paper-input>
         </div>

--- a/src/lancie-login/lancie-login-form.html
+++ b/src/lancie-login/lancie-login-form.html
@@ -274,6 +274,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this.$.registerUsername.validate();
       },
 
+      validateUsername: function() {
+        return this.$.username.validate();
+      },
+
       validateRegisterPassword: function() {
         if (!this.password || this.password === '') {
           this.passwordError = true;


### PR DESCRIPTION
Was previously throwing warnings in the console when you were typing in the username field of the login form.