### PR TITLE
Lazy load polyfill only on browsers without native custom elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,12 +51,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="stylesheet" href="styles/main.css">
 
-  <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-
   <script>
     window.Polymer = {
       lazyRegister: true
     };
+
+    // Load webcomponentsjs polyfill if browser does not support native
+    // Web Components
+    (function() {
+      'use strict';
+      var onload = function() {
+        // For native Imports, manually fire WebComponentsReady so user code
+        // can use the same code path for native and polyfill'd imports.
+        if (!window.HTMLImports) {
+          document.dispatchEvent(
+            new CustomEvent('WebComponentsReady', {bubbles: true})
+          );
+        }
+      };
+      var webComponentsSupported = (
+        'registerElement' in document &&
+        'import' in document.createElement('link') &&
+        'content' in document.createElement('template')
+      );
+      if (!webComponentsSupported) {
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = 'bower_components/webcomponentsjs/webcomponents-lite.min.js';
+        script.onload = onload;
+        document.head.appendChild(script);
+      } else {
+        onload();
+      }
+    })();
   </script>
 
   <script>


### PR DESCRIPTION
The polyfill is now only loaded in browsers without native custom elements, such as Firefox. It is not loaded in Chrome.