### PR TITLE
Remove import breaking contact form

### DIFF
--- a/src/lancie-content.html
+++ b/src/lancie-content.html
@@ -5,8 +5,6 @@
 <link rel="import" href="lancie-storage/lancie-auth-storage.html">
 <link rel="import" href="lancie-login/lancie-ajax.html">
 <link rel="import" href="lancie-login/lancie-login-check.html">
-<link rel="import" href="lancie-contact/lancie-contact.html">
-<link rel="import" href="lancie-contact/lancie-contact-success.html">
 
 <dom-module id="lancie-content">
   <template>


### PR DESCRIPTION
This import is not needed and results in actually breaking when changing to the actual contact form page. It tries to register the contact form page but is unable to because the dom-module already exists. Looks like this only happens in production. Is this interesting to you @TimvdLippe?