### PR TITLE
Change ticket types for live deadline display

### DIFF
--- a/src/lancie-ticket-page/lancie-ticket-item.html
+++ b/src/lancie-ticket-page/lancie-ticket-item.html
@@ -125,9 +125,9 @@
         deadlineDisplay: {
           type: Object,
           value: {
-            Early: 'deadline',
-            Normal: 'deadline',
-            Late: 'deadline',
+            'EARLY': 'deadline',
+            'NORMAL': 'deadline',
+            'LATE': 'deadline',
           },
         },
         color: String,


### PR DESCRIPTION
Users can't see the ticket deadlines due to wrong matching.