### PR TITLE
Remove time zone usage

### DIFF
--- a/src/lancie-ticket-page/lancie-ticket-item.html
+++ b/src/lancie-ticket-page/lancie-ticket-item.html
@@ -210,7 +210,7 @@
         }
         var deadlineType = this.deadlineDisplay[ticket.ticketType];
         if (deadlineType === 'deadline') {
-          return 'Available until: ' + new Date(this.ticket.deadline).toLocaleString('nl', {hour12: false});
+          return 'Available until: ' + new Date(this.ticket.deadline).toLocaleString('nl', {hour12: false, timeZone: 'UTC',});
         } else if (deadlineType === 'limit') {
           return 'Only ' + (ticket.limit - ticket.numberSold) + ' left!';
         } else {


### PR DESCRIPTION
Fixes #390 

Use UTC timezone since we are not working with a timezone. We don't have to compensate for time zone changes, so usage of the default user timezone is not needed.