### PR TITLE
Check in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,34 @@
+<FilesMatch "\.(jpg|JPG|jpeg|png|gif|swf|svg|json)$">
+Header set Cache-Control "max-age=604800, public"
+</FilesMatch>
+
+<FilesMatch "\.(txt|xml|js|css|md)$">
+Header set Cache-Control "max-age=86400"
+</FilesMatch>
+
+<FilesMatch "\.(html)$">
+Header set Cache-Control "max-age=0, private, no-store, no-cache, must-revalidate"
+</FilesMatch>
+
+AddType text/plain md
+
+AddOutputFilterByType DEFLATE "text/html" \
+  "text/plain" \
+  "application/javascript" \
+  "application/json" \
+  "image/svg+xml"
+
+AddCharset UTF-8 .html
+AddCharset UTF-8 .md
+
+RewriteEngine On
+  # If an existing asset or directory is requested go to it as it is
+  RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
+  RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
+  RewriteRule ^ - [L]
+
+  # If the requested resource doesn't exist, use index.html
+  # If the request is not for a valid file
+  RewriteCond %{REQUEST_URI} !.(js|html|jpg|JPG|jpeg|png|gif|swf|svg|json|txt|xml|css|md)$
+  RewriteRule ^ /index.html
+


### PR DESCRIPTION
File requests now return 404 when requested. This solves some nasty infinite loading loops when a file was missing in the build.

I have already updated the `.htaccess` on the server, this is simply checking in the resource.

Do we want this file also in the build?

Fixes #347