### PR TITLE
Dynamic close listener

### DIFF
--- a/src/lancie-activity/lancie-activity-dialog.html
+++ b/src/lancie-activity/lancie-activity-dialog.html
@@ -120,15 +120,7 @@ This code may only be used under the BSD style license found at https://github.c
      */
     openDialog: function() {
       this.$.lancieDialog.open();
-    },
-
-    /**
-     * Closes the lancie-dialog
-     * @return {void}
-     */
-    closeDialog: function() {
-      this.$.lancieDialog.close();
-    },
+    }
   });
   </script>
 </dom-module>

--- a/src/lancie-activity/lancie-activity-dialog.html
+++ b/src/lancie-activity/lancie-activity-dialog.html
@@ -93,7 +93,7 @@ This code may only be used under the BSD style license found at https://github.c
     <lancie-dialog id="lancieDialog">
       <div class="dialog-header">
         <h2><strong>[[data.sponsor.name]]</strong> <span>[[data.headerTitle]]</span></h2>
-        <paper-icon-button icon="close" on-tap="closeDialog"></paper-icon-button>
+        <paper-icon-button icon="close" dialog-dismiss></paper-icon-button>
       </div>
       <div class="card-content">
         <lancie-activity-content data="[[data]]"></lancie-activity-content>

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -147,8 +147,8 @@ simply give it the `dialog-dismiss` attribute.
         var host = this;
         var dismissEls = this.querySelectorAll('[dialog-dismiss]');
         for (var i = 0; i < dismissEls.length; i++) {
-          var dismissEl = dismissEls[i];
-          dismissEl.addEventListener('tap', function() { host.close(); });
+          dismissEls[i].addEventListener('tap',
+            function() { host.close(); });
         }
       },
 

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -146,10 +146,8 @@ simply give it the `dialog-dismiss` attribute.
       addDismissListeners: function() {
         var host = this;
         this.walkTheDOM(this.$.actualDialog, function(node) {
-          if (typeof node.hasAttribute === 'function') {
-            if (node.hasAttribute('dialog-dismiss')) {
-              node.addEventListener('tap', function() {host.close();});
-            }
+          if (node.hasAttribute && node.hasAttribute('dialog-dismiss')) {
+             node.addEventListener('tap', function() {host.close();});
           }
         });
       },

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -147,7 +147,8 @@ simply give it the `dialog-dismiss` attribute.
         var host = this;
         var dismissEls = this.querySelectorAll('[dialog-dismiss]');
         for (var i = 0; i < dismissEls.length; i++) {
-          dismissEls[i].addEventListener('tap', function() {host.close();});
+          var dismissEl = dismissEls[i];
+          dismissEl.addEventListener('tap', function() { host.close(); });
         }
       },
 

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -145,22 +145,9 @@ simply give it the `dialog-dismiss` attribute.
 
       addDismissListeners: function() {
         var host = this;
-        this.walkTheDOM(this.$.actualDialog, function(node) {
-          if (node.hasAttribute && node.hasAttribute('dialog-dismiss')) {
-             node.addEventListener('tap', function() {host.close();});
-          }
-        });
-      },
-
-      // From: http://www.javascriptcookbook.com/article/Traversing-DOM-subtrees-with-a-recursive-walk-the-DOM-function/
-      walkTheDOM: function(node, func) {
-        if (func) {
-          func(node);
-          node = node.firstChild;
-          while (node) {
-            this.walkTheDOM(node, func);
-            node = node.nextSibling;
-          }
+        var dismissEls = this.querySelectorAll('[dialog-dismiss]');
+        for (var i = 0; i < dismissEls.length; i++) {
+          dismissEls[i].addEventListener('tap', function() {host.close();});
         }
       },
 

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -140,18 +140,28 @@ simply give it the `dialog-dismiss` attribute.
       is: 'lancie-dialog',
 
       ready: function() {
+        this.addDismissListeners();
+      },
+
+      addDismissListeners: function() {
         var host = this;
-        var dialogChildren = this.$.actualDialog.children;
-        for (var i = 0; i < dialogChildren.length; i++) {
-          var child = dialogChildren[i];
-          if (child.classList.contains('buttons')) {
-            var buttons = child.children;
-            for (var j = 0; j < buttons.length; j++) {
-              var button = buttons[j];
-              if (button.hasAttribute('dialog-dismiss')) {
-                button.addEventListener('tap', function() {host.close();});
-              }
+        this.walkTheDOM(this.$.actualDialog, function(node) {
+          if (typeof node.hasAttribute === 'function') {
+            if (node.hasAttribute('dialog-dismiss')) {
+              node.addEventListener('tap', function() {host.close();});
             }
+          }
+        });
+      },
+
+      // From: http://www.javascriptcookbook.com/article/Traversing-DOM-subtrees-with-a-recursive-walk-the-DOM-function/
+      walkTheDOM: function(node, func) {
+        if (func) {
+          func(node);
+          node = node.firstChild;
+          while (node) {
+            this.walkTheDOM(node, func);
+            node = node.nextSibling;
           }
         }
       },

--- a/src/lancie-dialog/lancie-dialog.html
+++ b/src/lancie-dialog/lancie-dialog.html
@@ -138,23 +138,20 @@ simply give it the `dialog-dismiss` attribute.
   (function() {
     Polymer({
       is: 'lancie-dialog',
-      listeners: {
-        'tap': 'isDismissButton'
-      },
 
-      /**
-      * Find out if the tapped target was the dismiss button
-      */
-      isDismissButton: function(event) {
-        // Search for the element with dialog-dismiss,
-        // from the root target until this (excluded).
-        var path = Polymer.dom(event).path;
-        for (var i = 0; i < path.indexOf(this); i++) {
-          var target = path[i];
-          if (target.hasAttribute && (target.hasAttribute('dialog-dismiss') )) {
-            this.close();
-            event.stopPropagation();
-            break;
+      ready: function() {
+        var host = this;
+        var dialogChildren = this.$.actualDialog.children;
+        for (var i = 0; i < dialogChildren.length; i++) {
+          var child = dialogChildren[i];
+          if (child.classList.contains('buttons')) {
+            var buttons = child.children;
+            for (var j = 0; j < buttons.length; j++) {
+              var button = buttons[j];
+              if (button.hasAttribute('dialog-dismiss')) {
+                button.addEventListener('tap', function() {host.close();});
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Instead of responding to every tap event and figuring out whether it was on an element with the `dialog-dismiss` attribute this adds a `tap` `eventListener` to all elements with the `dialog-dismiss` attribute.