### PR TITLE
Fix sponsor logos flex wrapping in safari (and hopefully safari mobile)

### DIFF
--- a/src/lancie-sponsors/lancie-sponsors.html
+++ b/src/lancie-sponsors/lancie-sponsors.html
@@ -9,19 +9,29 @@
       :host {
         display: block;
         width: 100%;
+        --logo-width: 250px;
       }
 
       .main-sponsors img {
         margin-right: 32px;
-        min-width: 200px;
+        width: var(--logo-width);
       }
 
       img {
-        max-width: 250px;
+        /*max-width: 250px;*/
         object-fit: contain;
         vertical-align: middle;
         margin: 10px 6px;
       }
+      
+      /*
+       * Safari hack
+       * Makes flex wrapping work
+       */
+      .flex, .flex-1, .flex-2, .flex-3, .flex-4 {
+        flex-basis: var(--logo-width);
+      }
+      /*End Safari hack*/
     </style>
 
     <div id="grid" class="layout horizontal wrap flex">

--- a/src/lancie-sponsors/lancie-sponsors.html
+++ b/src/lancie-sponsors/lancie-sponsors.html
@@ -18,7 +18,6 @@
       }
 
       img {
-        /*max-width: 250px;*/
         object-fit: contain;
         vertical-align: middle;
         margin: 10px 6px;


### PR DESCRIPTION
If the previous fixes in `my-area` fixed it for safari mobile this works for safari mobile too.