### PR TITLE
Fix time not displaying as intended in FF and some mobile browser(s)

### DIFF
--- a/src/lancie-ticket-page/lancie-ticket-item.html
+++ b/src/lancie-ticket-page/lancie-ticket-item.html
@@ -209,6 +209,10 @@
         }
         var deadlineType = this.deadlineDisplay[ticket.ticketType];
         if (deadlineType === 'deadline') {
+          // This is needed to make sure all browsers interpret the time as UTC
+          // ISO 8601 specifies that date/time literals without time zone information
+          // should be interpreted as local time, while ES5.1 specifies it should
+          // be interpreted as UTC.
           this.ticket.deadline = this.ticket.deadline + "Z";
           return 'Available until: ' + new Date(this.ticket.deadline).toLocaleString('nl', {hour12: false, timeZone: 'UTC',});
         } else if (deadlineType === 'limit') {

--- a/src/lancie-ticket-page/lancie-ticket-item.html
+++ b/src/lancie-ticket-page/lancie-ticket-item.html
@@ -209,12 +209,12 @@
         }
         var deadlineType = this.deadlineDisplay[ticket.ticketType];
         if (deadlineType === 'deadline') {
-          // This is needed to make sure all browsers interpret the time as UTC
+          // The + "Z" is needed to make sure all browsers interpret the time as UTC
           // ISO 8601 specifies that date/time literals without time zone information
           // should be interpreted as local time, while ES5.1 specifies it should
           // be interpreted as UTC.
-          this.ticket.deadline = this.ticket.deadline + "Z";
-          return 'Available until: ' + new Date(this.ticket.deadline).toLocaleString('nl', {hour12: false, timeZone: 'UTC',});
+          return 'Available until: ' + new Date(this.ticket.deadline + "Z")
+            .toLocaleString('nl', {hour12: false, timeZone: 'UTC'});
         } else if (deadlineType === 'limit') {
           return 'Only ' + (ticket.limit - ticket.numberSold) + ' left!';
         } else {

--- a/src/lancie-ticket-page/lancie-ticket-item.html
+++ b/src/lancie-ticket-page/lancie-ticket-item.html
@@ -209,6 +209,7 @@
         }
         var deadlineType = this.deadlineDisplay[ticket.ticketType];
         if (deadlineType === 'deadline') {
+          this.ticket.deadline = this.ticket.deadline + "Z";
           return 'Available until: ' + new Date(this.ticket.deadline).toLocaleString('nl', {hour12: false, timeZone: 'UTC',});
         } else if (deadlineType === 'limit') {
           return 'Only ' + (ticket.limit - ticket.numberSold) + ' left!';


### PR DESCRIPTION
This makes sure all browsers following the ISO-8601 *or* the ES5.1 date/time string literal standard interpret our date/time string the same. This is needed because those two standards are not aligned. I like this even less as what we saw in #391, but right now there is no other way to fix this. (unless someone finds a date string literal parse function in js where you can specify the timezone on parse)