### PR TITLE
Use webcomponentsjs-loader.js instead of custom loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,41 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </style>
 
-  <script>
-    window.Polymer = {
-      lazyRegister: true,
-      dom: 'shadow'
-    };
-
-    // Load webcomponentsjs polyfill if browser does not support native
-    // Web Components
-    (function() {
-      'use strict';
-      var onload = function() {
-        // For native Imports, manually fire WebComponentsReady so user code
-        // can use the same code path for native and polyfill'd imports.
-        if (!window.HTMLImports) {
-          document.dispatchEvent(
-            new CustomEvent('WebComponentsReady', {bubbles: true})
-          );
-        }
-      };
-      var webComponentsSupported = (
-        'registerElement' in document &&
-        'import' in document.createElement('link') &&
-        'content' in document.createElement('template')
-      );
-      if (!webComponentsSupported) {
-        var script = document.createElement('script');
-        script.async = true;
-        script.src = 'bower_components/webcomponentsjs/webcomponents-loader.js';
-        script.onload = onload;
-        document.head.appendChild(script);
-      } else {
-        onload();
-      }
-    })();
-  </script>
+  <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
 
   <script>
   'use strict';


### PR DESCRIPTION
In Polymer 2 we have lazyRegister and shadow dom by default. Also, the new version of the polyfills will only load the polyfills you actually need for each browser.