### PR TITLE
Re-add eventlistener to the index

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       document.addEventListener('toast', (e) => {
         showToast(e.detail);
       });
+      document.addEventListener('navigate', (e) => {
+        appLocation.path = e.detail.page;
+      });
       document.addEventListener('refreshToast', (e) => {
         showToast({text: 'Unable to connect to server. Try refreshing the page.'});
       });


### PR DESCRIPTION
The navigate eventListener was previously removed by index (I assume), which resulted in the registration not working properly anymore and also non functioning navigation buttons and actions in other places.