### PR TITLE
Update footer version and fix styling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "web-animations-js": "web-animations/web-animations-js#^2.2.2",
     "google-map": "GoogleWebComponents/google-map#^2.0.0",
     "polymer": "polymer/polymer#^2.0.0",
-    "wisvch-footer": "wisvch/wisvch-footer#2.0-preview",
+    "wisvch-footer": "wisvch/wisvch-footer#^2.0.0",
     "iron-lazy-pages": "TimvdLippe/iron-lazy-pages#^2.0.0",
     "lancie-dialog": "AreaFiftyLAN/lancie-dialog#^2.0.0",
     "lancie-ajax": "AreaFiftyLAN/lancie-ajax#^2.1.2",

--- a/src/index-imports.html
+++ b/src/index-imports.html
@@ -19,3 +19,4 @@
 
 <link rel="import" href="lancie-storage/lancie-auth-storage.html">
 <link rel="import" href="lancie-login/lancie-login-check.html">
+<link rel="import" href="lancie-section/lancie-section.html">


### PR DESCRIPTION
`<wisvch-footer>` 2.0.0 has been released and the branch has been deleted. Also fix the styling by adding the missing import for `<lancie-section>`.