### PR TITLE
Changed text-align of paragraphs to justify.

### DIFF
--- a/src/lancie-commission/lancie-commission.html
+++ b/src/lancie-commission/lancie-commission.html
@@ -27,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       p {
         margin-top: 0px;
+        text-align: justify;
       }
 
       .textual, .visual {

--- a/src/lancie-home-page/lancie-home-page.html
+++ b/src/lancie-home-page/lancie-home-page.html
@@ -33,6 +33,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: none !important;
       }
 
+      p {
+        text-align: justify;
+      }
+
       iron-image {
         width: 100vw;
         height: 600px;


### PR DESCRIPTION
Implements #548
Doesn't work for FAQs for some reason, couldn't get it to work for markdown-elements I think.