### PR TITLE
Log out button

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       display: flex;
     }
 
-    .navigation-tabs a {
+    .navigation-tabs a, .navigation-tabs lancie-logout-button {
       text-decoration: none;
       color: var(--secondary-color);
       font-size: 16px;
@@ -186,6 +186,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <a data-route="tickets" href="/tickets">Tickets</a>
               <a data-route="my-area" href="/my-area">My Area</a>
               <a data-route="seatmap" href="/seatmap">Seatmap</a>
+              <lancie-logout-button hidden$="[[!user]]"></lancie-logout-button>
             </iron-selector>
           </nav>
         </app-toolbar>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <a data-route="tickets" href="/tickets">Tickets</a>
               <a data-route="my-area" href="/my-area">My Area</a>
               <a data-route="seatmap" href="/seatmap">Seatmap</a>
-              <lancie-logout-button hidden$="[[!user]]"></lancie-logout-button>
             </iron-selector>
           </nav>
         </app-toolbar>

--- a/src/index-imports.html
+++ b/src/index-imports.html
@@ -19,4 +19,5 @@
 
 <link rel="import" href="lancie-storage/lancie-auth-storage.html">
 <link rel="import" href="lancie-login/lancie-login-check.html">
+<link rel="import" href="lancie-login/lancie-logout-button.html">
 <link rel="import" href="lancie-section/lancie-section.html">

--- a/src/lancie-login/lancie-logout-button.html
+++ b/src/lancie-login/lancie-logout-button.html
@@ -1,0 +1,83 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/lancie-ajax/lancie-ajax.html">
+<link rel="import" href="../lancie-storage/lancie-auth-storage.html">
+
+<dom-module id="lancie-logout-button">
+<template>
+  <style>
+    :host {
+      display: block;
+      height: 100%;
+      min-height: 100%;
+    }
+
+    :host [hidden] {
+        display: none !important;
+    }
+    
+    a {
+      text-decoration: none;
+      color: var(--secondary-color);
+      /*font-size: 16px;
+      font-weight: 400;
+      line-height: 24px;
+      min-height: 48px;
+      height: inherit;
+      display: flex;
+      align-items: center;*/
+    }
+  </style>
+
+  <lancie-ajax id="ajaxLogout" refurl="logout" method="POST" on-lancie-ajax="onLogoutResponse"></lancie-ajax>
+
+  <a href="#" on-tap="tryLogout">Logout</a>
+
+</template>
+<script>
+  (function () {
+  'use strict';
+
+  const authStorage = document.querySelector('lancie-auth-storage');
+
+  class LancieLogoutButton extends Polymer.Element {
+    static get is() {
+      return 'lancie-logout-button';
+    }
+
+    static get properties() {
+      return {
+      };
+    }
+
+    tryLogout() {
+        this.$.ajaxLogout.generateRequest();
+    }
+
+    onLogoutResponse(e, request) {
+        if (request.succeeded) {
+          authStorage.clearToken();
+          this.dispatchEvent(new CustomEvent('user-changed', {
+              detail: {value: null},
+              bubbles: true,
+              composed: true
+          }));
+          this.dispatchEvent(new CustomEvent('navigate', {
+              detail: {page: ''},
+              bubbles: true,
+              composed: true
+          }));
+          // TODO ensure a the user pages (e.g. My Area) are refreshed so that once you are logged out no personal information is "in cache/already loaded" 
+        } else {
+          this.dispatchEvent(new CustomEvent('toast', {
+            detail: 'You are not logged in',
+            bubbles: true,
+            composed: true
+          }));
+        }
+    }
+  }
+
+  customElements.define(LancieLogoutButton.is, LancieLogoutButton);
+  })();
+  </script>
+</dom-module>

--- a/src/lancie-login/lancie-logout-button.html
+++ b/src/lancie-login/lancie-logout-button.html
@@ -7,46 +7,25 @@
   <style>
     :host {
       display: block;
-      height: 100%;
-      min-height: 100%;
+      margin: 8px;
     }
 
-    :host [hidden] {
-        display: none !important;
-    }
-    
-    a {
-      text-decoration: none;
+    paper-button {
+      background-color: var(--primary-color);
       color: var(--secondary-color);
-      /*font-size: 16px;
-      font-weight: 400;
-      line-height: 24px;
-      min-height: 48px;
-      height: inherit;
-      display: flex;
-      align-items: center;*/
+      font-weight: 450;
     }
   </style>
 
   <lancie-ajax id="ajaxLogout" refurl="logout" method="POST" on-lancie-ajax="onLogoutResponse"></lancie-ajax>
 
-  <a href="#" on-tap="tryLogout">Logout</a>
+  <paper-button raised on-tap="tryLogout">Logout</paper-button>
 
 </template>
 <script>
-  (function () {
-  'use strict';
-
-  const authStorage = document.querySelector('lancie-auth-storage');
-
   class LancieLogoutButton extends Polymer.Element {
     static get is() {
       return 'lancie-logout-button';
-    }
-
-    static get properties() {
-      return {
-      };
     }
 
     tryLogout() {
@@ -54,19 +33,24 @@
     }
 
     onLogoutResponse(e, request) {
-        if (request.succeeded) {
-          authStorage.clearToken();
+      if (request.succeeded) {
+          this.dispatchEvent(new CustomEvent('clear-token', {
+              bubbles: true,
+              composed: true
+          }));
           this.dispatchEvent(new CustomEvent('user-changed', {
-              detail: {value: null},
+              detail: {value: {}},
               bubbles: true,
               composed: true
           }));
-          this.dispatchEvent(new CustomEvent('navigate', {
-              detail: {page: ''},
-              bubbles: true,
-              composed: true
+          this.dispatchEvent(new CustomEvent('toast', {
+            detail: 'You successfully logged out',
+            bubbles: true,
+            composed: true
           }));
-          // TODO ensure a the user pages (e.g. My Area) are refreshed so that once you are logged out no personal information is "in cache/already loaded" 
+          window.sessionStorage.clear();
+          // note: some extensions block this
+          window.location.replace("/");
         } else {
           this.dispatchEvent(new CustomEvent('toast', {
             detail: 'You are not logged in',
@@ -78,6 +62,5 @@
   }
 
   customElements.define(LancieLogoutButton.is, LancieLogoutButton);
-  })();
   </script>
 </dom-module>

--- a/src/lancie-login/lancie-logout-button.html
+++ b/src/lancie-login/lancie-logout-button.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/lancie-ajax/lancie-ajax.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../lancie-storage/lancie-auth-storage.html">
 
 <dom-module id="lancie-logout-button">

--- a/src/lancie-my-area/lancie-my-area.html
+++ b/src/lancie-my-area/lancie-my-area.html
@@ -10,24 +10,25 @@
   <template>
     <style include="iron-flex iron-flex-alignment iron-flex-factors"></style>
     <style>
-    :host {
-      display: block;
-      --card-min-width: 300px;
-    }
+      :host {
+        display: block;
+        --card-min-width: 300px;
+      }
 
-    .card {
-      margin: 8px;
-      min-width: var(--card-min-width);
-    }
+      .card {
+        margin: 8px;
+        min-width: var(--card-min-width);
+      }
 
-    /*
-     * Safari hack
-     * Makes flex wrapping work
-     */
-    .flex, .flex-1, .flex-2, .flex-3 {
-      flex-basis: var(--card-min-width);
-    }
-    /*End Safari hack*/
+      /*
+       * Safari hack
+       * Makes flex wrapping work
+       */
+      .flex, .flex-1, .flex-2, .flex-3 {
+        flex-basis: var(--card-min-width);
+      }
+
+      /*End Safari hack*/
 
     </style>
     <lancie-section type="primary full" header="My Area - {{user.profile.displayName}}">
@@ -45,13 +46,18 @@
     </lancie-section>
   </template>
   <script>
-  Polymer({
-    is: 'lancie-my-area',
-    properties: {
-      user: {
-        type: Object
+    class LancieMyArea extends Polymer.Element {
+      static get is() {
+        return 'lancie-my-area';
+      }
+
+      static get properties() {
+        return {
+          user: Object,
+        }
       }
     }
-  });
+
+    customElements.define(LancieMyArea.is, LancieMyArea);
   </script>
 </dom-module>

--- a/src/lancie-my-area/my-area-discord.html
+++ b/src/lancie-my-area/my-area-discord.html
@@ -22,6 +22,7 @@
       color: var(--secondary-color);
       background: var(--primary-color);
       text-align: center;
+      font-weight: 450;
     }
 
     .block > *:first-child {

--- a/src/lancie-my-area/my-area-profile.html
+++ b/src/lancie-my-area/my-area-profile.html
@@ -13,6 +13,7 @@
 <link rel="import" href="../../bower_components/lancie-ajax/lancie-ajax.html">
 <link rel="import" href="../../bower_components/lancie-login-form/lancie-passwords.html">
 <link rel="import" href="profile-edit-form.html">
+<link rel="import" href="../lancie-login/lancie-logout-button.html"/>
 
 <dom-module id="my-area-profile">
   <template>
@@ -97,7 +98,7 @@
         <div class="layout horizontal center">
           <iron-icon icon="communication:email" item-icon></iron-icon>
           <div class="item flex">
-            <div>{{user.username}}</div>
+            <div>{{user.email}}</div>
           </div>
         </div>
 
@@ -105,7 +106,7 @@
         <div class="layout horizontal center" hidden$="[[editingPassword]]">
           <iron-icon icon="icons:lock" item-icon></iron-icon>
           <div class="item flex">
-            <div>&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;&#9679;</div>
+            <div id="pwPlaceholder"></div>
           </div>
         </div>
         <div class="layout horizontal center" hidden$="[[!editingPassword]]">
@@ -129,44 +130,56 @@
         <paper-icon-button on-tap="submitEdit" icon="icons:check" id="checkIcon"></paper-icon-button>
         <paper-tooltip for="checkIcon" offset="0" animation-delay="1">Save changes</paper-tooltip>
       </div>
+      <lancie-logout-button></lancie-logout-button>
     </paper-card>
-
   </template>
   <script>
-  'use strict';
+    class MyAreaProfile extends Polymer.Element {
 
-  (function() {
-    Polymer({
-      is: 'my-area-profile',
-      properties: {
-        user: Object,
-        editingProfile: {
-          type: Boolean,
-          value: false
-        },
-        editingPassword: {
-          type: Boolean,
-          value: false
-        },
-        currentPassword: {
-          type: String
+      static get is() {
+        return 'my-area-profile';
+      }
+
+      static get properties() {
+        return {
+          user: Object,
+          editingProfile: {
+            type: Boolean,
+            value: false
+          },
+          editingPassword: {
+            type: Boolean,
+            value: false
+          },
+          currentPassword: {
+            type: String
+          },
+          pwPlaceholder: {
+            type: String,
+            value: () => { return '&#9679;'.repeat(12);}
+          }
         }
-      },
+      }
 
-      switchProfileForm: function() {
+      ready() {
+        super.ready();
+        this.$.pwPlaceholder.innerHTML = this.pwPlaceholder;
+      }
+
+      switchProfileForm() {
         this.editingProfile = !this.editingProfile;
-      },
+      }
 
-      switchPasswordForm: function() {
+      switchPasswordForm() {
         this.editingPassword = !this.editingPassword;
-      },
+      }
 
-      resetForms: function() {
+      resetForms() {
         this.editingProfile = false;
         this.editingPassword = false;
-      },
+      }
 
-      submitEdit: function() {
+      submitEdit() {
         if (this.editingProfile) {
           if (this.$.profileForm.validateAndSubmit()) {
             this.switchProfileForm();
@@ -178,9 +191,9 @@
             this.switchPasswordForm();
           }
         }
-      },
+      }
 
-      onPasswordUpdate: function(e, request) {
+      onPasswordUpdate(e, request) {
         if (request.succeeded) {
           this.fire('toast', {text: 'Password updated.'});
         } else {
@@ -190,17 +203,17 @@
             this.fire('toast', {text: 'Password update failed.'});
           }
         }
-      },
+      }
 
-      isEditing: function(editingProfile, editingPassword) {
+      isEditing(editingProfile, editingPassword) {
         return editingProfile || editingPassword;
-      },
+      }
 
-      _checkEmpty: function(value) {
+      _checkEmpty(value) {
         return value || 'Not yet filled in, please click the pencil icon in the bottom left to complete your profile.';
-      },
+      }
+    }
 
-    });
-  })();
+    customElements.define(MyAreaProfile.is, MyAreaProfile);
   </script>
 </dom-module>

--- a/src/lancie-my-area/my-area-profile.html
+++ b/src/lancie-my-area/my-area-profile.html
@@ -195,12 +195,24 @@
 
       onPasswordUpdate(e, request) {
         if (request.succeeded) {
-          this.fire('toast', {text: 'Password updated.'});
+          this.dispatchEvent(new CustomEvent('toast', {
+            detail: 'Password updated.',
+            bubbles: true,
+            composed: true
+          }));
         } else {
           if (request.request.status === 403) {
-            this.fire('toast', {text: 'Wrong password.'});
+            this.dispatchEvent(new CustomEvent('toast', {
+              detail: 'Wrong password.',
+              bubbles: true,
+              composed: true
+            }));
           } else {
-            this.fire('toast', {text: 'Password update failed.'});
+            this.dispatchEvent(new CustomEvent('toast', {
+              detail: 'Password update failed.',
+              bubbles: true,
+              composed: true
+            }));
           }
         }
       }

--- a/src/lancie-storage/lancie-auth-storage.html
+++ b/src/lancie-storage/lancie-auth-storage.html
@@ -54,11 +54,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
       },
 
+      created: function() {
+        this.addEventListener('clear-token', e => {this.clearToken(e);});
+      },
+
       getToken: function() {
         return this.auth && this.auth.token;
       },
 
-      clearToken: function() {
+      clearToken: function(e) {
         this.auth = {};
         this.$.ajax.clearToken();
         this.$.form.clearToken();

--- a/src/lancie-storage/lancie-auth-storage.html
+++ b/src/lancie-storage/lancie-auth-storage.html
@@ -58,6 +58,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this.auth && this.auth.token;
       },
 
+      clearToken: function() {
+        this.auth = {};
+        this.$.ajax.clearToken();
+        this.$.form.clearToken();
+      },
+      // TODO include these functions in their respective repositories.
+      // Feel free to use the following code for testing purposes
+      //
+      // clearToken: function() {
+      //  this.auth = {};
+      //  this.$.ajax.injectToken('');
+      //  this.$.form.injectToken('');
+      // },
+
       storeToken: function(token) {
         this.initial = false;
         this.auth = {


### PR DESCRIPTION
Work in progress.

Issues:

`<lancie-logout-button hidden$="[[!user]]"></lancie-logout-button>`  is not sufficient to hide the logout button when a user is not logged in.

Also we need to find a way to refresh the "cache" or local storage after logging out. Logging out brings you to the homepage but returning to the My Area page still shows the users information. Using ```window.location.replace("/");``` instead of a `navigate` event seemed to work...