### PR TITLE
Let Travis push Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ script:
 - docker build --no-cache --pull -t wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER .
 after_success:
 - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]; then
- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
- docker push wisvch/areafiftylan-frontend-beta:$TRAVIS_BUILD_NUMBER;
-fi
+  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  docker push wisvch/areafiftylan-frontend-beta:$TRAVIS_BUILD_NUMBER;
+  fi
 - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "live" ]; then
- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
- docker push wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER;
-fi
+  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  docker push wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER;
+  fi
 notifications:
-  email: false
+   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: node_js
 services:
 - docker
 # At least Docker 17.05 is needed for multi-stage builds, so upgrade
@@ -10,12 +11,12 @@ script:
 - docker build --no-cache --pull -t wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER .
 after_success:
 - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]; then
-  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-  docker push wisvch/areafiftylan-frontend-beta:$TRAVIS_BUILD_NUMBER;
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push wisvch/areafiftylan-frontend-beta:$TRAVIS_BUILD_NUMBER;
   fi
 - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "live" ]; then
-  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-  docker push wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER;
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER;
   fi
 notifications:
    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y install docker-ce
 script:
-- docker build -t lancie-frontend .
+- docker build --no-cache --pull -t wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER .
+after_success:
+- if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]; then
+ docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+ docker push wisvch/areafiftylan-frontend-beta:$TRAVIS_BUILD_NUMBER;
+fi
+- if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "live" ]; then
+ docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+ docker push wisvch/areafiftylan-frontend:$TRAVIS_BUILD_NUMBER;
+fi
 notifications:
-email: false
+  email: false


### PR DESCRIPTION
This PR lets travis push docker images. It currently supports both staging and live images.
Not sure if the docker upgrade is still required of if that's upgraded already.

Configuration from CH Beheer is needed before merge!