### PR TITLE
CSS tweaks and fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: #333;
       background-color: #eeecec;
       margin: 0;
-      --lancie-primary: #1a2b43;
-      --lancie-secondary: #ffe574;
-      --app-toolbar-height: 64px;
+      --primary-color: #1a2b43;
+      --secondary-color: #ffe574;
     }
 
     app-toolbar {
-      background-color: var(--lancie-primary);
-      height: var(--app-toolbar-height);
+      background-color: var(--primary-color);
+      height: 64px;
       justify-content: space-between;
       display: flex;
       align-items: center;
@@ -106,7 +105,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     .navigation-tabs a {
       text-decoration: none;
-      color: var(--lancie-secondary);
+      color: var(--secondary-color);
       font-size: 16px;
       font-weight: 400;
       line-height: 24px;
@@ -117,15 +116,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       align-items: center;
     }
     .navigation-tabs a.iron-selected {
-      border-bottom: 2px solid var(--lancie-secondary);
+      border-bottom: 2px solid var(--secondary-color);
     }
 
     img {
       margin-left: 16px;
     }
 
-    paper-icon-button {
-      color: var(--lancie-secondary);
+    app-toolbar paper-icon-button {
+      color: var(--secondary-color);
       height: 48px;
       width: 48px;
     }

--- a/src/lancie-404.html
+++ b/src/lancie-404.html
@@ -14,7 +14,7 @@
         margin-right: auto;
         margin-top: 10px;
         display: block;
-        --paper-card-header-color: var(--lancie-secondary);
+        --paper-card-header-color: var(--secondary-color);
         max-width: 500px;
 
         --paper-card-header-text: {
@@ -25,8 +25,8 @@
       }
 
       paper-card {
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
       }
 
       img {

--- a/src/lancie-activity/lancie-activity-dialog.html
+++ b/src/lancie-activity/lancie-activity-dialog.html
@@ -22,18 +22,18 @@ This code may only be used under the BSD style license found at https://github.c
       }
 
       .dialog-header {
-        background-color: var(--lancie-primary);
+        background-color: var(--primary-color);
         display: flex;
         justify-content: space-between;
       }
 
       .dialog-header h2 {
         margin-left: 10px;
-        color: var(--lancie-secondary);
+        color: var(--secondary-color);
       }
 
       .dialog-header paper-icon-button {
-        color: var(--lancie-secondary);
+        color: var(--secondary-color);
         margin: 8px;
       }
 

--- a/src/lancie-activity/lancie-activity-sponsor.html
+++ b/src/lancie-activity/lancie-activity-sponsor.html
@@ -24,9 +24,9 @@ This code may only be used under the BSD style license found at https://github.c
         padding-bottom: 61.8%;
       }
       .prizes-block .prizes-header {
-        background-color: var(--lancie-primary);
+        background-color: var(--primary-color);
         padding: 3px 10px;
-        color: var(--lancie-secondary);
+        color: var(--secondary-color);
       }
       .prizes-block ol {
         margin: 0;

--- a/src/lancie-commission/lancie-commission-member.html
+++ b/src/lancie-commission/lancie-commission-member.html
@@ -19,8 +19,8 @@
       }
 
       iron-icon {
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
         padding: 14px 14px;
         width: 30px;
         height: 30px;

--- a/src/lancie-contact/lancie-contact.html
+++ b/src/lancie-contact/lancie-contact.html
@@ -31,8 +31,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
         margin: auto;
         width: 90%;
-        color: var(--lancie-secondary);
-        background-color: var(--lancie-primary);
+        color: var(--secondary-color);
+        background-color: var(--primary-color);
         text-align: center;
       }
     </style>

--- a/src/lancie-home-page/lancie-image-slider.html
+++ b/src/lancie-home-page/lancie-image-slider.html
@@ -9,13 +9,13 @@
       :host {
         display: block;
         height: 500px;
-        background-color: var(--lancie-primary);
+        background-color: var(--primary-color);
       }
 
       .image-slider iron-image {
         position: absolute;
         width: inherit;
-        background-color: var(--lancie-primary);
+        background-color: var(--primary-color);
         -webkit-transition: opacity 1s ease-in-out;
         -moz-transition: opacity 1s ease-in-out;
         -o-transition: opacity 1s ease-in-out;
@@ -54,7 +54,7 @@
       }
 
       .text a {
-        color: var(--lancie-secondary);
+        color: var(--secondary-color);
       }
 
       .text.large {
@@ -63,8 +63,8 @@
       }
 
       paper-material {
-        background-color: var(--lancie-secondary);
-        color: var(--lancie-primary);
+        background-color: var(--secondary-color);
+        color: var(--primary-color);
         padding: 16px;
         border-radius: 2px;
         display: inline-block;

--- a/src/lancie-home-page/lancie-info-blocks.html
+++ b/src/lancie-home-page/lancie-info-blocks.html
@@ -5,7 +5,7 @@
   <style>
   :host {
     display: block;
-    background-color: var(--lancie-primary);
+    background-color: var(--primary-color);
   }
 
   .container {
@@ -21,7 +21,7 @@
     min-height: 36px;
     border-radius: 50%;
     margin: auto 16px auto 0;
-    border: 4px solid var(--lancie-secondary);
+    border: 4px solid var(--secondary-color);
     background: transparent;
     content: "";
   }
@@ -29,7 +29,7 @@
   .container > div {
     display: flex;
     min-width: 250px;
-    color: var(--lancie-secondary);
+    color: var(--secondary-color);
     padding: 20px 0;
   }
 

--- a/src/lancie-home-page/lancie-subscribe-mail-form.html
+++ b/src/lancie-home-page/lancie-subscribe-mail-form.html
@@ -18,16 +18,6 @@
       lancie-form.mail-input iron-icon {
         margin-right: 12px;
       }
-
-      lancie-error.lancie-info {
-        border-left: 4px solid var(--lancie-primary);
-        background: var(--paper-light-blue-50);
-        color: var(--lancie-primary);
-      }
-
-      [hidden] {
-        display: none !important;
-      }
     </style>
 
     <lancie-form id="mailForm" refurl="subscriptions" method="POST" class="mail-input" on-response="onResponse">

--- a/src/lancie-login/lancie-login.html
+++ b/src/lancie-login/lancie-login.html
@@ -33,8 +33,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       paper-button {
         width: calc(50% - 15px);
         margin-top: 4px;
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
       }
 
       .actions {

--- a/src/lancie-my-area/my-area-discord.html
+++ b/src/lancie-my-area/my-area-discord.html
@@ -19,8 +19,8 @@
       display: block;
       margin: auto;
       width: 90%;
-      color: var(--lancie-secondary);
-      background: var(--lancie-primary);
+      color: var(--secondary-color);
+      background: var(--primary-color);
       text-align: center;
     }
 

--- a/src/lancie-my-area/my-area-order-item.html
+++ b/src/lancie-my-area/my-area-order-item.html
@@ -27,10 +27,6 @@
       padding: 0;
     }
 
-    lancie-dialog {
-      width: 840px;
-    }
-
     .order-stats > div > b {
       display: inline-block;
       width: 120px;

--- a/src/lancie-my-area/my-area-orders.html
+++ b/src/lancie-my-area/my-area-orders.html
@@ -24,8 +24,8 @@
     }
 
     paper-tooltip {
-      --paper-tooltip-background: var(--lancie-primary);
-      --paper-tooltip-text-color: var(--lancie-secondary);
+      --paper-tooltip-background: var(--primary-color);
+      --paper-tooltip-text-color: var(--secondary-color);
     }
 
     .title-text {

--- a/src/lancie-my-area/my-area-profile.html
+++ b/src/lancie-my-area/my-area-profile.html
@@ -27,8 +27,8 @@
     }
 
     paper-tooltip {
-      --paper-tooltip-background: var(--lancie-primary);
-      --paper-tooltip-text-color: var(--lancie-secondary);
+      --paper-tooltip-background: var(--primary-color);
+      --paper-tooltip-text-color: var(--secondary-color);
     }
 
     .item {

--- a/src/lancie-my-area/my-area-seat.html
+++ b/src/lancie-my-area/my-area-seat.html
@@ -18,8 +18,8 @@
     }
 
     paper-tooltip {
-      --paper-tooltip-background: var(--lancie-primary);
-      --paper-tooltip-text-color: var(--lancie-secondary);
+      --paper-tooltip-background: var(--primary-color);
+      --paper-tooltip-text-color: var(--secondary-color);
     }
     </style>
 

--- a/src/lancie-my-area/my-area-teams.html
+++ b/src/lancie-my-area/my-area-teams.html
@@ -38,8 +38,8 @@
     }
 
     paper-tooltip {
-      --paper-tooltip-background: var(--lancie-primary);
-      --paper-tooltip-text-color: var(--lancie-secondary);
+      --paper-tooltip-background: var(--primary-color);
+      --paper-tooltip-text-color: var(--secondary-color);
     }
 
     hr {
@@ -54,8 +54,8 @@
     paper-badge {
       --paper-badge-margin-left: -20px;
       --paper-badge-margin-bottom: -18px;
-      --paper-badge-background: var(--lancie-primary);
-      --paper-badge-text-color: var(--lancie-secondary);
+      --paper-badge-background: var(--primary-color);
+      --paper-badge-text-color: var(--secondary-color);
     }
     </style>
     <paper-card class="layout vertical flex" heading="Teams" elevation="1" animated-shadow="true">

--- a/src/lancie-order-check.html
+++ b/src/lancie-order-check.html
@@ -12,8 +12,8 @@
       }
 
       paper-button {
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
       }
     </style>
     <lancie-ajax id="ajaxConfirmOrder" token="{{token}}" refurl="orders/[[orderId]]/status" on-lancie-ajax="onResponse"></lancie-ajax>

--- a/src/lancie-password/lancie-password-reset-request.html
+++ b/src/lancie-password/lancie-password-reset-request.html
@@ -31,8 +31,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .btn-primary {
-        color: var(--lancie-secondary);
-        background: var(--lancie-primary);
+        color: var(--secondary-color);
+        background: var(--primary-color);
       }
     </style>
 

--- a/src/lancie-password/lancie-password-reset.html
+++ b/src/lancie-password/lancie-password-reset.html
@@ -33,8 +33,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
         width: calc(50% - 15px);
         text-align: center;
-        color: var(--lancie-secondary);
-        background: var(--lancie-primary);
+        color: var(--secondary-color);
+        background: var(--primary-color);
       }
     </style>
 

--- a/src/lancie-seatmap/lancie-seatmap.html
+++ b/src/lancie-seatmap/lancie-seatmap.html
@@ -30,10 +30,10 @@ This code may only be used under the BSD style license found at https://github.c
 
     .grouplabel {
       width: 100%;
-      color: var(--lancie-secondary);
+      color: var(--secondary-color);
       font-size: 32px;
       font-weight: bold;
-      background: var(--lancie-primary);
+      background: var(--primary-color);
       box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
                   0 1px 5px 0 rgba(0, 0, 0, 0.12),
                   0 3px 1px -2px rgba(0, 0, 0, 0.2);

--- a/src/lancie-section/lancie-section.html
+++ b/src/lancie-section/lancie-section.html
@@ -58,16 +58,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     .primary h1 {
-      color: var(--lancie-primary);
+      color: var(--primary-color);
     }
 
     .secondary {
-      background-color: var(--lancie-primary);
+      background-color: var(--primary-color);
       color: rgba(255, 255, 255, 0.87);
     }
 
     .secondary h1 {
-      color: var(--lancie-secondary);
+      color: var(--secondary-color);
     }
 
     @media(max-width: 1017px) {

--- a/src/lancie-ticket-page/lancie-ticket-basket.html
+++ b/src/lancie-ticket-page/lancie-ticket-basket.html
@@ -26,8 +26,8 @@
     }
 
     paper-button {
-      background: var(--lancie-primary);
-      color: var(--lancie-secondary);
+      background: var(--primary-color);
+      color: var(--secondary-color);
       width: 100%;
       margin: 0 auto;
     }

--- a/src/lancie-ticket-page/lancie-ticket-page.html
+++ b/src/lancie-ticket-page/lancie-ticket-page.html
@@ -31,8 +31,8 @@ This code may only be used under the BSD style license found at https://github.c
 
       .tabs {
         display: flex;
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
         font-size: 16px;
         text-align: center;
       }
@@ -47,8 +47,8 @@ This code may only be used under the BSD style license found at https://github.c
 
       paper-progress {
         width: 100%;
-        --paper-progress-active-color: var(--lancie-secondary);
-        --paper-progress-container-color: var(--lancie-primary);
+        --paper-progress-active-color: var(--secondary-color);
+        --paper-progress-container-color: var(--primary-color);
       }
 
       .paper-material {
@@ -67,8 +67,8 @@ This code may only be used under the BSD style license found at https://github.c
       }
       
       .next-button {
-        background-color: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
       }
 
       .next-button[disabled] {

--- a/src/lancie-timeline/lancie-timeline.html
+++ b/src/lancie-timeline/lancie-timeline.html
@@ -16,8 +16,8 @@
 
     paper-tabs {
       --paper-tabs: {
-        background: var(--lancie-primary);
-        color: var(--lancie-secondary);
+        background: var(--primary-color);
+        color: var(--secondary-color);
       }
       ;
     }


### PR DESCRIPTION
This PR actually fixes the colors in firefox ~and edge~. The problem was caused by the CSS leaking to the other elements due to not properly using shadow dom in edge and firefox, R126 fixes this.

The other issue we had was the dialog for the order in my area floating to the left, which was caused by a leftover CSS statement from previous dialog implementation.

Lastly, I removed some redundant CSS due to the fact that the lancie-error element now handles all the styling and colors. I should have spotted this in #521, but failed to.
  
  