### PR TITLE
Serve bundled ES6 as modern

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -9,8 +9,8 @@
    "scripts/*"
   ],
   "builds": [
-    {"name":"fallback", "preset": "es5-bundled", "basePath": true},
-    {"name": "modern", "preset": "es6-unbundled", "browserCapabilities": ["es2015"], "basePath": true, "addPushManifest": false}
+    {"name":"fallback", "preset": "es5-bundled", "basePath": true,"addPushManifest": false},
+    {"name": "modern", "preset": "es6-bundled", "browserCapabilities": ["es2015"], "basePath": true, "addPushManifest": false}
   ],
   "fragments": [
     "src/lancie-home-page/lancie-home-page.html",


### PR DESCRIPTION
As we're not using push anyway, bundled is faster to serve