### PR TITLE
Lastpass workaround, fix loading the page

### DIFF
--- a/ce-fix.html
+++ b/ce-fix.html
@@ -1,0 +1,3 @@
+<script>
+  document.createElement = Document.prototype.createElement;
+</script>

--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
   <base href="/">
+  <link rel="import" href="ce-fix.html">
   <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
 </head>
 
@@ -324,12 +325,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       // We can't use async import, as that screws up the loading mechanism :(
-      // Load the custom elements workaround first
-      const ceWorkaround = document.createElement('link');
-      ceWorkaround.rel = 'import';
-      ceWorkaround.href = 'ce-fix.html';
-      document.head.appendChild(ceWorkaround);
-
       const linkElement = document.createElement('link');
       linkElement.rel = 'import';
       linkElement.href = 'src/index-imports.html';

--- a/index.html
+++ b/index.html
@@ -324,6 +324,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       // We can't use async import, as that screws up the loading mechanism :(
+      // Load the custom elements workaround first
+      const ceWorkaround = document.createElement('link');
+      ceWorkaround.rel = 'import';
+      ceWorkaround.href = 'ce-fix.html';
+      document.head.appendChild(ceWorkaround);
+
       const linkElement = document.createElement('link');
       linkElement.rel = 'import';
       linkElement.href = 'src/index-imports.html';

--- a/polymer.json
+++ b/polymer.json
@@ -32,6 +32,7 @@
     "src/lancie-password/lancie-password-reset-request-success.html"
   ],
   "extraDependencies": [
+    "ce-fix.html",
     ".htaccess",
     "manifest.json",
     "favicon.ico",


### PR DESCRIPTION
The webpage now loads with lastpass enabled, using [this](https://gist.github.com/usergenic/9baf88a24dcbc77bc808339755a7d436) workaround. I couldn't use the html import for some reason, so I added it before the js import.