### PR TITLE
Lazy load the Facebook iframe

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
   "strict": true,
   "globals": {
     "Polymer": false,
-    "customElements": false
+    "customElements": false,
+    "Lancie": false
   }
 }

--- a/src/lancie-facebook/lancie-facebook.html
+++ b/src/lancie-facebook/lancie-facebook.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../lazy-load.html">
+
 <dom-module id="lancie-facebook">
   <template>
     <style>
@@ -26,30 +28,12 @@
       'use strict';
 
       const iframeUrl = 'https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fareafiftylan%2F&tabs=timeline&width=292&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId';
-      const observerOptions = {
-        rootMargin: '40px'
-      };
 
-      class LancieFacebook extends Polymer.Element {
+      class LancieFacebook extends Lancie.lazyLoad(Polymer.Element) {
         static get is() { return 'lancie-facebook'; }
-
-        connectedCallback() {
-          super.connectedCallback();
-
-          const callback = (entries) => {
-            // The first load triggers the observer, but we are not yet fully
-            // loaded to show the image, thus we are not in view.
-            // Swallow this event by checking if we are actually intersecting
-            if (entries[0].isIntersecting && !this.$.frame.src) {
-              this.$.frame.src = iframeUrl;
-            }
-          };
-
-          if (window.IntersectionObserver) {
-            const observer = new IntersectionObserver(callback, observerOptions);
-            observer.observe(this);
-          } else {
-            callback();
+        lazyCallback() {
+          if (!this.$.frame.src) {
+            this.$.frame.src = iframeUrl;
           }
         }
       }

--- a/src/lancie-facebook/lancie-facebook.html
+++ b/src/lancie-facebook/lancie-facebook.html
@@ -14,7 +14,7 @@
       }
     </style>
 
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fareafiftylan%2F&tabs=timeline&width=292&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId"
+    <iframe id="frame"
             scrolling="no"
             frameborder="0"
             allowTransparency="true">
@@ -25,9 +25,35 @@
     (function() {
       'use strict';
 
-      Polymer({
-        is: 'lancie-facebook',
-      });
+      const iframeUrl = 'https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fareafiftylan%2F&tabs=timeline&width=292&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId';
+      const observerOptions = {
+        rootMargin: '40px'
+      };
+
+      class LancieFacebook extends Polymer.Element {
+        static get is() { return 'lancie-facebook'; }
+
+        connectedCallback() {
+          super.connectedCallback();
+
+          const callback = (entries) => {
+            // The first load triggers the observer, but we are not yet fully
+            // loaded to show the image, thus we are not in view.
+            // Swallow this event by checking if we are actually intersecting
+            if (entries[0].isIntersecting && !this.$.frame.src) {
+              this.$.frame.src = iframeUrl;
+            }
+          };
+
+          if (window.IntersectionObserver) {
+            const observer = new IntersectionObserver(callback, observerOptions);
+            observer.observe(this);
+          } else {
+            callback();
+          }
+        }
+      }
+      customElements.define(LancieFacebook.is, LancieFacebook);
     })();
   </script>
 </dom-module>

--- a/src/lancie-google-map/lancie-google-map.html
+++ b/src/lancie-google-map/lancie-google-map.html
@@ -1,0 +1,35 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/google-map/google-map.html">
+<link rel="import" href="../../bower_components/google-map/google-map-marker.html">
+<link rel="import" href="../lazy-load.html">
+
+<dom-module id="lancie-google-map">
+  <template>
+    <template is="dom-if" if="[[lazyLoaded]]">
+      <google-map latitude="51.995694" longitude="4.373950" zoom="14" disable-zoom fit-to-markers draggable="false" api-key="{{googleMapsToken.message}}">
+        <google-map-marker slot="markers" latitude="51.995694" longitude="4.373950" draggable="true" title="Area FiftyLAN"></google-map-marker>
+      </google-map>
+    </template>
+  </template>
+  <script>
+  'use strict';
+    (function() {
+      class LancieGoogleMap extends Lancie.lazyLoad(Polymer.Element) {
+        static get is() { return 'lancie-google-map'; }
+        static get properties() {
+          return {
+            googleMapsToken: Object,
+            lazyLoaded: {
+              type: Boolean,
+              value: false
+            }
+          };
+        }
+        lazyCallback() {
+          this.lazyLoaded = true;
+        }
+      }
+      customElements.define(LancieGoogleMap.is, LancieGoogleMap);
+    })();
+  </script>
+</dom-module>

--- a/src/lancie-home-page/lancie-home-page.html
+++ b/src/lancie-home-page/lancie-home-page.html
@@ -9,8 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/lancie-ajax/lancie-ajax.html">
-<link rel="import" href="../../bower_components/google-map/google-map.html">
-<link rel="import" href="../../bower_components/google-map/google-map-marker.html">
 <link rel="import" href="../lancie-section/lancie-section.html">
 <link rel="import" href="../lancie-activity/lancie-activities.html">
 <link rel="import" href="../lancie-commission/lancie-commission.html">
@@ -18,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../lancie-timeline/lancie-timeline.html">
 <link rel="import" href="../lancie-faq/lancie-faq.html">
 <link rel="import" href="../lancie-facebook/lancie-facebook.html">
+<link rel="import" href="../lancie-google-map/lancie-google-map.html">
 <link rel="import" href="../lancie-my-area/lancie-terms-of-service.html">
 <link rel="import" href="lancie-banner.html">
 <link rel="import" href="lancie-info-blocks.html">
@@ -217,11 +216,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </lancie-section>
 
-    <template is="dom-if" if="{{googleMapsToken}}" restamp="true">
+    <template is="dom-if" if="[[googleMapsToken]]" restamp="true">
       <div class="google-maps-section">
-        <google-map latitude="51.995694" longitude="4.373950" zoom="14" disable-zoom fit-to-markers draggable="false" api-key="{{googleMapsToken.message}}">
-          <google-map-marker slot="markers" latitude="51.995694" longitude="4.373950" draggable="true" title="Area FiftyLAN"></google-map-marker>
-        </google-map>
+        <lancie-google-map google-maps-token="[[googleMapsToken]]"></lancie-google-map>
       </div>
     </template>
 

--- a/src/lazy-load.html
+++ b/src/lazy-load.html
@@ -1,0 +1,30 @@
+<script>
+'use strict';
+
+const observerOptions = {
+  rootMargin: '40px'
+};
+
+window.Lancie = window.Lancie || {};
+window.Lancie.lazyLoad = (clazz) => class extends clazz {
+  connectedCallback() {
+    super.connectedCallback();
+
+    const callback = (entries) => {
+      // The first load triggers the observer, but we are not yet fully
+      // loaded to show the image, thus we are not in view.
+      // Swallow this event by checking if we are actually intersecting
+      if (entries[0].isIntersecting) {
+        this.lazyCallback();
+      }
+    };
+
+    if (window.IntersectionObserver) {
+      const observer = new window.IntersectionObserver(callback, observerOptions);
+      observer.observe(this);
+    } else {
+      callback();
+    }
+  }
+};
+</script>

--- a/src/lazy-load.html
+++ b/src/lazy-load.html
@@ -2,7 +2,7 @@
 'use strict';
 
 const observerOptions = {
-  rootMargin: '40px'
+  rootMargin: '100px'
 };
 
 window.Lancie = window.Lancie || {};


### PR DESCRIPTION
On small screens, the network requests of the Facebook element should no longer be there on first load. Instead, when the frame moves into view, the network requests should trigger and the iframe loads. For browsers that do not support the observer, the old behavior of instant loading remains.