### PR TITLE
lancie-login to ES6 class, add icon to switch button, add lancie iconset

### DIFF
--- a/src/index-imports.html
+++ b/src/index-imports.html
@@ -10,6 +10,7 @@ Polymer.setPassiveTouchGestures(true);
 <link rel="import" href="../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
 <link rel="import" href="../bower_components/app-layout/app-drawer/app-drawer.html">
 <link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
+<!-- TODO: Generate custom icon set -->
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 

--- a/src/index-imports.html
+++ b/src/index-imports.html
@@ -10,7 +10,6 @@ Polymer.setPassiveTouchGestures(true);
 <link rel="import" href="../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
 <link rel="import" href="../bower_components/app-layout/app-drawer/app-drawer.html">
 <link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
-<!-- TODO: Generate custom icon set -->
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 
@@ -22,6 +21,7 @@ Polymer.setPassiveTouchGestures(true);
 
 <link rel="import" href="../bower_components/paper-toast/paper-toast.html">
 
+<link rel="import" href="lancie-icons.html">
 <link rel="import" href="lancie-storage/lancie-auth-storage.html">
 <link rel="import" href="lancie-login/lancie-login-check.html">
 <link rel="import" href="lancie-section/lancie-section.html">

--- a/src/lancie-icons.html
+++ b/src/lancie-icons.html
@@ -1,0 +1,8 @@
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg size="24" name="lancie">
+  <svg><defs>
+    <g id="cached"><path d="M19 8l-4 4h3c0 3.31-2.69 6-6 6-1.01 0-1.97-.25-2.8-.7l-1.46 1.46C8.97 19.54 10.43 20 12 20c4.42 0 8-3.58 8-8h3l-4-4zM6 12c0-3.31 2.69-6 6-6 1.01 0 1.97.25 2.8.7l1.46-1.46C15.03 4.46 13.57 4 12 4c-4.42 0-8 3.58-8 8H1l4 4 4-4H6z"></path></g>
+  </defs></svg>
+</iron-iconset-svg>

--- a/src/lancie-login/lancie-login.html
+++ b/src/lancie-login/lancie-login.html
@@ -22,19 +22,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         max-width: 400px;
       }
 
-      [hidden] {
-        display: none !important;
-      }
-
       h2 {
         margin: 0;
       }
 
       paper-button {
-        width: calc(50% - 15px);
         margin-top: 4px;
         background-color: var(--primary-color);
         color: var(--secondary-color);
+      }
+
+      paper-button > iron-icon {
+        margin-right: 4px;
       }
 
       .actions {
@@ -43,60 +42,63 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <h2>[[_getAction(registering)]]</h2>
-      <div class="card-content">
-        <lancie-login-form id="loginForm" registering="[[registering]]" order-id="[[orderId]]" on-enter="submit"></lancie-login-form>
-      </div>
-      <div class="actions">
-        <paper-button raised on-tap="switchForm">Change to [[_getSwitchAction(registering)]]</paper-button>
-      </div>
-    </lancie-card>
+    <div class="card-content">
+      <lancie-login-form id="loginForm" registering="[[registering]]" order-id="[[orderId]]"
+                         on-enter="submit"></lancie-login-form>
+    </div>
+    <div class="actions">
+      <paper-button raised on-tap="switchForm"><iron-icon icon="lancie:cached"></iron-icon>Switch to [[_getSwitchAction(registering)]]</paper-button>
+    </div>
 
   </template>
   <script>
-  (function() {
-  'use strict';
-  
-  Polymer({
-    is: 'lancie-login',
-    properties: {
-      registering: {
-        type: Boolean,
-        value: false,
-        notify: true,
-      },
-      orderId: String,
-    },
-
-    switchForm: function() {
-      this.$.loginForm.clearError();
-      this.registering = !this.registering;
-    },
-
-    submit: function() {
-      if (this.registering) {
-        this.register();
-      } else {
-        this.login();
+    class LancieLogin extends Polymer.Element {
+      static get is() {
+        return 'lancie-login';
       }
-    },
 
-    register: function() {
-      this.$.loginForm.tryRegister();
-    },
+      static get properties() {
+        return {
+          registering: {
+            type: Boolean,
+            value: false,
+            notify: true,
+          },
+          orderId: String,
+        };
+      }
 
-    login: function() {
-      this.$.loginForm.tryLogIn();
-    },
+      switchForm() {
+        this.$.loginForm.clearError();
+        this.registering = !this.registering;
+      }
 
-    _getAction: function(registering) {
-      return registering ? 'Register' : 'Log In';
-    },
+      submit() {
+        if (this.registering) {
+          this.register();
+        } else {
+          this.login();
+        }
+      }
 
-    _getSwitchAction: function(registering) {
-      return this._getAction(!registering);
-    },
+      register() {
+        this.$.loginForm.tryRegister();
+      }
 
-  });
-  })();
+      login() {
+        this.$.loginForm.tryLogIn();
+      }
+
+      _getAction(registering) {
+        return registering ? 'Register' : 'Log In';
+      }
+
+      _getSwitchAction(registering) {
+        return this._getAction(!registering);
+      }
+
+    }
+
+    customElements.define(LancieLogin.is, LancieLogin);
   </script>
 </dom-module>


### PR DESCRIPTION
After spotting this 

![screenshot from 2018-01-28 21-57-20](https://user-images.githubusercontent.com/18485279/35487020-0e2dde4e-0477-11e8-80bb-5101f0fbf875.png)

in `lancie-login`, I decided to immediately refactor it a bit.

- To ES6 class-based syntax
- Added "switch" icon to help with indicating that the button is for switching rather than continuing (closes #580 )
- Added lancie iconset