### PR TITLE
Use numeric uid in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN addgroup -g ${gid} ${group} \
 
 RUN npm install -g prpl-server
 
-USER ${user}
+USER ${uid}
 WORKDIR /home/${user}/app
 COPY --from=builder /app/build/ ./
 


### PR DESCRIPTION
This allows platforms like Kubernetes to detect that the container will
not run as root.