### PR TITLE
Improve mobile styling

### DIFF
--- a/src/lancie-home-page/lancie-banner.html
+++ b/src/lancie-home-page/lancie-banner.html
@@ -85,7 +85,7 @@
     }
 
     .banner {
-      height: 300px;
+      height: 240px;
     }
 
     .logo-container > span {

--- a/src/lancie-section/lancie-section.html
+++ b/src/lancie-section/lancie-section.html
@@ -72,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     @media(max-width: 1017px) {
       .content {
-        padding: 30px 8px;
+        padding: 16px 8px;
       }
     }
     </style>


### PR DESCRIPTION
Slightly improved styling on mobile:
- Decreased the banner height
- Deceased padding for sections

Before:
![chrome_2018-04-26_22-23-13](https://user-images.githubusercontent.com/18485279/39332481-d98fa980-49a7-11e8-8088-0a6966a577de.png)

After:
![chrome_2018-04-26_22-21-58](https://user-images.githubusercontent.com/18485279/39332497-e5884224-49a7-11e8-9a0e-22e2be2c057b.png)
