### PR TITLE
Only show address fields when needed

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "registry": "https://registry.bower.io"
+}

--- a/src/lancie-my-area/lancie-profile-edit.html
+++ b/src/lancie-my-area/lancie-profile-edit.html
@@ -85,12 +85,14 @@
           <paper-input label="Phone Number" name="phoneNumber" type="text" value="{{profile.phoneNumber}}" required></paper-input>
         </div>
         <div>
-          <iron-icon icon="lancie:location-on"></iron-icon>
-          <div class="group">
-            <paper-input label="Address" name="address" type="text" value="{{profile.address}}" required></paper-input>
-            <paper-input label="Zipcode" name="zipcode" type="text" value="{{profile.zipcode}}" required></paper-input>
-            <paper-input label="City" name="city" type="text" value="{{profile.city}}" required></paper-input>
-          </div>
+          <template is="dom-if" if="[[addressNeeded]]">
+            <iron-icon icon="lancie:location-on"></iron-icon>
+            <div class="group" >
+              <paper-input label="Address" name="address" type="text" value="{{profile.address}}" required></paper-input>
+              <paper-input label="Zipcode" name="zipcode" type="text" value="{{profile.zipcode}}" required></paper-input>
+              <paper-input label="City" name="city" type="text" value="{{profile.city}}" required></paper-input>
+            </div>
+          </template>
         </div>
       </div>
     </lancie-form>
@@ -106,6 +108,10 @@
           user: Object,
           profile: Object,
           profileChanged: Boolean,
+          addressNeeded: {
+            type: Boolean,
+            value: true
+          },
         };
       }
       static get observers() {

--- a/src/lancie-my-area/my-area-profile.html
+++ b/src/lancie-my-area/my-area-profile.html
@@ -58,6 +58,8 @@
 
     </style>
 
+    <lancie-ajax auto-fire id="ajaxTickets" refurl="users/current/tickets" handle-as="json" on-lancie-ajax="onTickets"></lancie-ajax>
+
     <paper-card class="layout vertical flex" heading="Profile">
       <div class="card-content">
 
@@ -81,15 +83,17 @@
               <div>{{_checkEmpty(user.profile.phoneNumber)}}</div>
             </div>
           </div>
-          <div class="layout horizontal center">
-            <iron-icon icon="lancie:location-on" item-icon></iron-icon>
-            <div class="item flex">
-              <div>{{user.profile.address}}</div>
-              <div>{{user.profile.zipcode}} {{user.profile.city}}</div>
+          <template is="dom-if" if="[[_hasPickupService(tickets)]]">
+            <div class="layout horizontal center">
+              <iron-icon icon="lancie:location-on" item-icon></iron-icon>
+              <div class="item flex">
+                <div>{{user.profile.address}}</div>
+                <div>{{user.profile.zipcode}} {{user.profile.city}}</div>
+              </div>
             </div>
-          </div>
+          </template>
         </div>
-        <lancie-profile-edit id="profileForm" hidden$="[[!editingProfile]]" user={{user}} on-profile-form-submit="submitEdit" on-no-changes="noChanges"></lancie-profile-edit>
+        <lancie-profile-edit id="profileForm" hidden$="[[!editingProfile]]" user={{user}} on-profile-form-submit="submitEdit" on-no-changes="noChanges" address-needed="[[_hasPickupService(tickets)]]"></lancie-profile-edit>
 
         <hr>
         <div class="layout horizontal center">
@@ -148,7 +152,8 @@
         },
         currentPassword: {
           type: String
-        }
+        },
+        tickets: Object,
       },
 
       switchProfileForm: function() {
@@ -198,8 +203,23 @@
         return editingProfile || editingPassword;
       },
 
+      onTickets: function(e, request) {
+        this.tickets = request.response.length > 0 ? request.response : false;
+      },
+
       _checkEmpty: function(value) {
         return value || 'Not yet filled in, please click the pencil icon in the bottom left to complete your profile.';
+      },
+
+      _hasPickupService(tickets) {
+        if (tickets) {
+          for (let i = 0; i < tickets.length; i++) {
+            if (tickets[i].enabledOptions.filter(o => o.name === 'pickupService').length >= 1) {
+              return true;
+            }
+          }
+        }
+        return false;
       },
 
     });

--- a/src/lancie-ticket-page/lancie-ticket-page.html
+++ b/src/lancie-ticket-page/lancie-ticket-page.html
@@ -143,7 +143,7 @@
           <lancie-ticket-basket class="flex-2" basket="[[basket]]" user="{{user}}"></lancie-ticket-basket>
         </div>
 
-        <lancie-login id="login" order-id="[[basket.id]]" registering="{{registering}}" on-logged-in="onLogin"></lancie-login>
+        <lancie-login id="login" order-id="[[basket.id]]" registering="{{registering}}"></lancie-login>
 
         <div>
           <h2>Fill in your profile</h2>
@@ -313,6 +313,8 @@
         this.$.ajaxCoupleOrder.generateRequest();
       } else if (basket.status === 'ANONYMOUS' && !this.$.orderStorage.orderStored()) {
         this.$.orderStorage.storeOrderId(basket.id);
+      } else if (basket.status === 'ASSIGNED' && user) {
+        this.selectTab(TABS.PROFILE);
       }
     },
 

--- a/src/lancie-ticket-page/lancie-ticket-page.html
+++ b/src/lancie-ticket-page/lancie-ticket-page.html
@@ -147,7 +147,7 @@
 
         <div>
           <h2>Fill in your profile</h2>
-          <lancie-profile-edit id="profileForm" user="{{user}}" on-profile-submitted="profileConfirmed" on-no-changes="profileConfirmed"></lancie-profile-edit>
+          <lancie-profile-edit id="profileForm" user="{{user}}" address-needed="[[_hasPickupService(basket.tickets)]]" on-profile-submitted="profileConfirmed" on-no-changes="profileConfirmed"></lancie-profile-edit>
         </div>
 
         <div>
@@ -198,6 +198,7 @@
       fromRegister: Boolean,
       query: String,
       registering: Boolean,
+
     },
     observers: [
       '_assignOrder(user, basket)'
@@ -337,6 +338,18 @@
       }
       return true;
     },
+
+    _hasPickupService(tickets) {
+      if (tickets) {
+        for (let i = 0; i < tickets.length; i++) {
+          if (tickets[i].enabledOptions.filter(o => o.name === 'pickupService').length >= 1) {
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+
   });
   })();
   </script>


### PR DESCRIPTION
This pull request hides the address fields during checkout and in My Area if the user does not have tickets with the pickup service.

Currently the server does not accept the requests without address fields (400 on /users/current/profile), so this PR is blocked until that is fixed.