### PR TITLE
Terms & Conditions update + small email section

### DIFF
--- a/src/lancie-ticket-page/lancie-terms-of-service-text.html
+++ b/src/lancie-ticket-page/lancie-terms-of-service-text.html
@@ -12,7 +12,7 @@
     <div>
       <h3>General Terms and Conditions</h3>
       <h3>0 Definitions</h3>
-      This document contains the general terms and conditions for “AreaFiftyLAN”, taking place from the 3rd of March until the 5th of March 2017, from now on referenced to as “the event”. The event is established by “Mathematics and Computer Science Study Association ‘Christiaan Huygens’” through the “LANCie Committee 2016-2017”, these two parties are from now on referenced to as “the organization”. Any other individual that is legally present at, or has the authority to be present at the event while not being part of the organization is considered to be a participant, if not stated otherwise. Every individual at the event must follow these terms and conditions.
+      This document contains the general terms and conditions for “AreaFiftyLAN”, taking place from the 1st of March until the 3rd of March 2019, from now on referenced to as “the event”. The event is established by “Mathematics and Computer Science Study Association ‘Christiaan Huygens’” through the “LANCie 2018-2019”, these two parties are from now on referenced to as “the organization”. Any other individual that is legally present at, or has the authority to be present at the event while not being part of the organization is considered to be a participant, if not stated otherwise. Every individual at the event must follow these terms and conditions.
       <h3>1 Validity</h3>
       The organization reserves the right to modify these general terms and conditions until the start date of the event without any form of report of reason. The Dutch legislation is in effect at all times. Any violation of the terms and conditions will be punished by a fee of an appropriate amount, determined by the organization unless specified otherwise.
       <h3>2 Tickets</h3>
@@ -64,14 +64,14 @@
       <h4>10.2 Prizes</h4>
       The organization reserves the right to modify or reduce the prizes according to the amount of registrations or other interventions. The prizewinner shall be present at the ceremony and personally collect the prize, unless a substitute is made known to the organization. In case of a team being the winner of a prize, one team member will suffice in collecting the prize.
       <h3>11 Accommodations</h3>
-      During the event overnight stay is possible. All participants will stay in the appointed rooms, each owning a reasonable amount of space as determined by the organization. This space will be used to sleep, thus only allowing enough room for an air mattress or something similar and a few belongings. Note that the participant is asked to take as little space as possible, meaning only single mattresses are allowed (when used by one person). Tents are not allowed inside the building, the organization will not be responsible for any violations outside the building of Cornelis Drebbelweg 5.
+      During the event overnight stay is possible. All participants will stay in the appointed rooms, each owning a reasonable amount of space as determined by the organization. This space will be used to sleep, thus only allowing enough room for an air mattress or something similar and a few belongings. Note that the participant is asked to take as little space as possible, meaning only single mattresses are allowed (when used by one person). Tents are not allowed inside the building, the organization will not be responsible for any violations outside the building of X (Unit Sports & Culture TU Delft).
       <h3>12 Prohibited objects</h3>
       Any object, not directly needed for gaming, that needs electricity to function is not permitted at the event. This excludes chargers for gadgets like mobile phones.
       Below is a list of objects which are not allowed at the event due to unnecessary, safety reasons and rules. Note that any similar objects that are not listed and have the same effect are also prohibited at the event.
       <ul>
-        <li>coolbox</li>
-        <li>refrigerator</li>
-        <li>fan/air conditioner</li>
+        <li>Coolbox</li>
+        <li>Refrigerator</li>
+        <li>Fan/air conditioner</li>
       </ul>
       <h3>13 Services</h3>
       <h4>13.1 Pickup Service</h4>
@@ -93,6 +93,8 @@
       The organization can not keep a permanent control on the software exchange through the server. Therefore, the organization is not responsible for possible copyrighted software which has been stored on or retrieved from the server. Nevertheless, it is illegal to reproduce any copyrighted material, without the author’s permission. Any possible illegal movement of protected software is the participant’s responsibility. The organization will not accept any liability for violating privacy. The organization ensures the participant’s privacy as far as is required legally. Hence, every participant is responsible for using any sort of software. Hereof, the organization will not accept liability for content, use or ownership. Note that all the above is nonapplicable for software provided by the organization, in that case she will take full responsibility for any inconveniences.
       <h3>15 Unspecified actions</h3>
       When a situation occurs that is not specified in this document, there will be an appropriate response. The sanction will be determined according to the severeness of the violation. The sanction is to be determined by the organization.
+      <h3>16 E-mail updates</h3>
+      By agreeing to these terms and conditions you agree to receiving an e-mail once a year to notify you of the next event. If you do not want to receive these emails, please contact us at <a href="mailto:unsubscribe.areafiftylan@ch.tudelft.nl">unsubscribe.areafiftylan@ch.tudelft.nl</a>.
     </div>
   </template>
   <script>


### PR DESCRIPTION
With the new law we have to be more transparent regarding the storage of contact information. I have added a temporary section in the terms & conditions so that it is at least stated somewhere that we use your email to send updates.

This update does not conclude the AVG shebang, which is why I created issue #657
