### PR TITLE
Change links on homepage

### DIFF
--- a/src/lancie-home-page/lancie-banner.html
+++ b/src/lancie-home-page/lancie-banner.html
@@ -131,8 +131,8 @@
 </div>
 
 <div class="links">
-  <a href="https://flitcie.ch.tudelft.nl/Bestuur-61/Area-FiftyLAN" target="_blank" rel="noopener noreferrer"><div>Check out the photos!</div></a>
-  <a href="https://www.facebook.com/areafiftylan" target="_blank" rel="noopener noreferrer"><div>Stay updated</div></a>
+  <a href="https://areafiftylan.nl/tickets" target="_self" rel="noopener noreferrer"><div>Get your ticket</div></a>
+  <a href="https://www.facebook.com/events/2126387947381690/" target="_blank" rel="noopener noreferrer"><div>Check the Facebook event</div></a>
 </div>
 
 </template>


### PR DESCRIPTION
Change links from "Check out the photos" and "Stay updated" to "Get your ticket" and "Check out the Facebook event".

### Before
![schermafbeelding 2019-01-03 om 18 34 42](https://user-images.githubusercontent.com/15840181/50652327-8309c280-0f86-11e9-910d-f01b7e646187.png)

### After
![schermafbeelding 2019-01-03 om 18 34 52](https://user-images.githubusercontent.com/15840181/50652335-88670d00-0f86-11e9-8799-31fbd3c19334.png)
