### PR TITLE
Fix validation of hidden fields

### DIFF
--- a/src/lancie-my-area/lancie-profile-edit.html
+++ b/src/lancie-my-area/lancie-profile-edit.html
@@ -85,7 +85,7 @@
           <paper-input label="Phone Number" name="phoneNumber" type="text" value="{{profile.phoneNumber}}" required></paper-input>
         </div>
         <div>
-          <template is="dom-if" if="[[addressNeeded]]">
+          <template is="dom-if" if="[[addressNeeded]]" restamp="true">
             <iron-icon icon="lancie:location-on"></iron-icon>
             <div class="group" >
               <paper-input label="Address" name="address" type="text" value="{{profile.address}}" required></paper-input>


### PR DESCRIPTION
Fix bug that prevented users from changing their profile if they registered without buying a ticket. Polymer had hidden the fields instead of removing them from the DOM, which caused them to still be validated by the .validate() method of iron-form. Adding the restamp attribute fixes this problem.